### PR TITLE
feat: Application settings page

### DIFF
--- a/.cursor/rules/FRONTEND_PATTERNS.mdc
+++ b/.cursor/rules/FRONTEND_PATTERNS.mdc
@@ -234,3 +234,126 @@ style={{
 - **Settings pages**: Centered, max-width 800px, section-based
 - **Forms**: Max-width 400px, consistent spacing
 - **Dropdowns**: Absolute positioning, z-index management, click-outside handling
+
+## UI Feature Entry Points
+
+When adding a new UI feature, consider which entry points are appropriate. **Always ask the user** which entry points should be added when implementing a new feature.
+
+### Available Entry Points
+
+| Entry Point | Location | Access Control | Use Case |
+|-------------|----------|----------------|----------|
+| **Avatar Menu** | `user-avatar-menu.tsx` | Role-based (`isAdmin`) | User/admin actions, settings, logout |
+| **Command Palette** | `command-palette/command-providers/` | Role-based in provider | Quick navigation, search, actions |
+| **App Shortcut Widget** | `dashboard/app-shortcut-widget.tsx` | Dashboard owner/admin | Dashboard shortcuts to app pages |
+| **Entity Shortcut Widget** | `dashboard/entity-shortcut-widget.tsx` | Dashboard owner/admin | Dashboard shortcuts to entity pages |
+| **App Bar** | `layout.tsx` | Visibility-based | Global navigation, always visible |
+| **Default Dashboard Patch** | Database seed/migration | All users | Pre-configured dashboard widgets |
+
+### Entry Point Checklist
+
+When implementing a new feature page, ask the user about:
+
+1. **Avatar Menu**: Should a menu item be added? (usually for settings/admin pages)
+2. **Command Palette**: Should a command provider be created? (for searchable/quick-access features)
+3. **Widget Support**: Should a new widget type or app shortcut be added? (for dashboard integration)
+4. **Default Dashboard**: Should the default dashboard include this feature? (for prominent features)
+5. **App Bar**: Should it appear in the main navigation? (rarely needed, for core features only)
+
+### Implementation Patterns
+
+#### Adding to Avatar Menu
+
+```typescript
+// user-avatar-menu.tsx
+const handleMyFeatureClick = () => {
+  const myFeatureRoute: Route<Record<string, never>> = {
+    url: '/my-feature',
+    component: () => <div>Loading...</div>,
+  }
+  navigateToRoute(injector, myFeatureRoute, {})
+  setIsMenuOpen(false)
+}
+
+// In render, add button (with role check if needed)
+{isAdmin && (
+  <Button onclick={handleMyFeatureClick}>
+    🔧 My Feature
+  </Button>
+)}
+```
+
+#### Adding Command Palette Provider
+
+```typescript
+// command-providers/my-feature.tsx
+import { getCurrentUser } from '@furystack/core'
+import type { CommandProvider } from '@furystack/shades-common-components'
+import { navigateToRoute } from '../../../navigate-to-route.js'
+import { myFeatureRoute } from '../../routes/my-routes.js'
+import type { SuggestionOptions } from './create-suggestion.js'
+import { createSuggestion, distinctByName } from './create-suggestion.js'
+
+const MyFeatureSuggestions: SuggestionOptions[] = [
+  {
+    name: 'My Feature',
+    description: 'Description of the feature',
+    icon: '🔧',
+    score: 1,
+    onSelected: ({ injector }) => {
+      navigateToRoute(injector, myFeatureRoute, {})
+    },
+  },
+]
+
+export const myFeatureCommandProvider: CommandProvider = async ({ term, injector }) => {
+  if (!term) return []
+
+  // Optional: role-based access
+  if (!(await getCurrentUser(injector))?.roles?.includes('admin')) return []
+
+  const fullHits = MyFeatureSuggestions.filter((c) => c.name.toLowerCase() === term.toLowerCase())
+    .map((c) => createSuggestion({ ...c, score: 1 }))
+  const startsWith = MyFeatureSuggestions.filter((c) => c.name.toLowerCase().startsWith(term.toLowerCase()))
+    .map((c) => createSuggestion({ ...c, score: 2 }))
+  const contains = MyFeatureSuggestions.filter((c) => c.name.toLowerCase().includes(term.toLowerCase()))
+    .map((c) => createSuggestion({ ...c, score: 3 }))
+  const descriptionContains = MyFeatureSuggestions.filter((c) => c.description.toLowerCase().includes(term.toLowerCase()))
+    .map((c) => createSuggestion({ ...c, score: 2 }))
+
+  return distinctByName(...fullHits, ...startsWith, ...contains, ...descriptionContains)
+}
+
+// Register in command-palette/index.tsx
+import { myFeatureCommandProvider } from './command-providers/my-feature.js'
+
+commandProviders={[
+  myFeatureCommandProvider,
+  // ... other providers
+]}
+```
+
+#### Adding App Shortcut Widget
+
+```typescript
+// 1. Update common/src/models/dashboard/app-shortcut-widget.ts
+export interface AppShortcutWidget {
+  type: 'app-shortcut'
+  appName: 'home' | 'browser' | /* ... */ | 'my-feature'
+}
+
+// 2. Update frontend/src/components/dashboard/app-shortcut-widget.tsx
+import { myFeatureRoute } from '../routes/my-routes.js'
+
+case 'my-feature':
+  return <IconUrlWidget {...rest} name="My Feature" url={myFeatureRoute.url} icon={<>🔧</>} />
+```
+
+### Access Control Patterns
+
+| Pattern | Implementation | Use Case |
+|---------|----------------|----------|
+| **Admin-only** | `isAdmin && <Button>` or `roles?.includes('admin')` | Admin features |
+| **Authenticated** | `currentUser && <Button>` | User features |
+| **Public** | Always render | Public features |
+| **Role-based** | `roles?.includes('role')` | Specific role features |

--- a/.cursor/rules/README.md
+++ b/.cursor/rules/README.md
@@ -20,19 +20,19 @@ When you open or edit a file, Cursor automatically loads the relevant rules base
 
 ## Rule Applicability Matrix
 
-| Rule File                                                    | Auto-Apply | File Patterns                                               | Description                       |
-| ------------------------------------------------------------ | ---------- | ----------------------------------------------------------- | --------------------------------- |
-| [CODE_STYLE.mdc](./CODE_STYLE.mdc)                           | ✅ Always  | `**/*.ts`, `**/*.tsx`                                       | Formatting, naming, organization  |
-| [TYPESCRIPT_GUIDELINES.mdc](./TYPESCRIPT_GUIDELINES.mdc)     | ✅ Always  | `**/*.ts`, `**/*.tsx`                                       | Type safety, NO `any`, generics   |
-| [TESTING_GUIDELINES.md](./TESTING_GUIDELINES.md)             | 🎯 Auto    | `**/*.spec.ts`, `**/*.spec.tsx`, `**/*.e2e.spec.ts`         | Vitest, Playwright, mocking       |
-| [ERROR_HANDLING.md](./ERROR_HANDLING.md)                     | 🎯 Auto    | `**/*.ts`, `**/*.tsx`, `**/actions/**`, `**/services/**`    | RequestError, Observable errors   |
-| [CACHE_HANDLING.md](./CACHE_HANDLING.md)                     | 🎯 Auto    | `**/*.ts`, `**/services/**`                                 | FuryStack Cache patterns          |
-| [OBSERVABLE_STATE.md](./OBSERVABLE_STATE.md)                 | 🎯 Auto    | `**/*.ts`, `**/*.tsx`, `**/services/**`                     | ObservableValue, useObservable    |
-| [PERFORMANCE_OPTIMIZATION.md](./PERFORMANCE_OPTIMIZATION.md) | 🎯 Auto    | `**/*.ts`, `**/*.tsx`, `**/components/**`, `**/services/**` | Optimization, disposal            |
-| [SCRIPT_EXECUTION.md](./SCRIPT_EXECUTION.md)                 | 🎯 Auto    | `package.json`, `**/*.sh`                                   | Package manager, CI/CD            |
-| [BACKEND_PATTERNS.mdc](./BACKEND_PATTERNS.mdc)               | 📘 Manual  | Backend development                                         | API, actions, authentication      |
-| [FRONTEND_PATTERNS.mdc](./FRONTEND_PATTERNS.mdc)             | 📘 Manual  | Frontend development                                        | Routing, Shades components, forms |
-| [main.mdc](./main.mdc)                                       | 📘 Manual  | Overview                                                    | Quick start guide                 |
+| Rule File                                                    | Auto-Apply | File Patterns                                               | Description                                        |
+| ------------------------------------------------------------ | ---------- | ----------------------------------------------------------- | -------------------------------------------------- |
+| [CODE_STYLE.mdc](./CODE_STYLE.mdc)                           | ✅ Always  | `**/*.ts`, `**/*.tsx`                                       | Formatting, naming, organization                   |
+| [TYPESCRIPT_GUIDELINES.mdc](./TYPESCRIPT_GUIDELINES.mdc)     | ✅ Always  | `**/*.ts`, `**/*.tsx`                                       | Type safety, NO `any`, generics                    |
+| [TESTING_GUIDELINES.md](./TESTING_GUIDELINES.md)             | 🎯 Auto    | `**/*.spec.ts`, `**/*.spec.tsx`, `**/*.e2e.spec.ts`         | Vitest, Playwright, mocking                        |
+| [ERROR_HANDLING.md](./ERROR_HANDLING.md)                     | 🎯 Auto    | `**/*.ts`, `**/*.tsx`, `**/actions/**`, `**/services/**`    | RequestError, Observable errors                    |
+| [CACHE_HANDLING.md](./CACHE_HANDLING.md)                     | 🎯 Auto    | `**/*.ts`, `**/services/**`                                 | FuryStack Cache patterns                           |
+| [OBSERVABLE_STATE.md](./OBSERVABLE_STATE.md)                 | 🎯 Auto    | `**/*.ts`, `**/*.tsx`, `**/services/**`                     | ObservableValue, useObservable                     |
+| [PERFORMANCE_OPTIMIZATION.md](./PERFORMANCE_OPTIMIZATION.md) | 🎯 Auto    | `**/*.ts`, `**/*.tsx`, `**/components/**`, `**/services/**` | Optimization, disposal                             |
+| [SCRIPT_EXECUTION.md](./SCRIPT_EXECUTION.md)                 | 🎯 Auto    | `package.json`, `**/*.sh`                                   | Package manager, CI/CD                             |
+| [BACKEND_PATTERNS.mdc](./BACKEND_PATTERNS.mdc)               | 📘 Manual  | Backend development                                         | API, actions, authentication                       |
+| [FRONTEND_PATTERNS.mdc](./FRONTEND_PATTERNS.mdc)             | 📘 Manual  | Frontend development                                        | Routing, Shades components, forms, UI entry points |
+| [main.mdc](./main.mdc)                                       | 📘 Manual  | Overview                                                    | Quick start guide                                  |
 
 **Legend:**
 
@@ -72,6 +72,18 @@ When you open or edit a file, Cursor automatically loads the relevant rules base
 - **CACHE_HANDLING.md** - If component uses cached data
 - **ERROR_HANDLING.md** - If component handles async operations
 - **PERFORMANCE_OPTIMIZATION.md** - If component is expensive
+
+### Adding a New UI Feature/Page
+
+**Apply:** FRONTEND_PATTERNS.mdc (see "UI Feature Entry Points" section)
+
+**Entry Point Checklist** - Ask user which to include:
+
+- [ ] Avatar Menu - menu item for user/admin actions
+- [ ] Command Palette - searchable command provider
+- [ ] App Shortcut Widget - dashboard widget support
+- [ ] Default Dashboard - pre-configured widget placement
+- [ ] App Bar - main navigation (rarely needed)
 
 ### Writing Tests
 

--- a/common/schemas/ai-api.json
+++ b/common/schemas/ai-api.json
@@ -133,6 +133,12 @@
                 }
               ]
             },
+            "logprobs": {
+              "type": "boolean"
+            },
+            "top_logprobs": {
+              "type": "number"
+            },
             "options": {
               "$ref": "#/definitions/Partial%3COptions%3E"
             }
@@ -198,6 +204,12 @@
               "const": "low"
             }
           ]
+        },
+        "logprobs": {
+          "type": "boolean"
+        },
+        "top_logprobs": {
+          "type": "number"
         },
         "options": {
           "$ref": "#/definitions/Partial%3COptions%3E"
@@ -511,6 +523,12 @@
         },
         "eval_duration": {
           "type": "number"
+        },
+        "logprobs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Logprob"
+          }
         }
       },
       "required": [
@@ -526,6 +544,38 @@
         "eval_count",
         "eval_duration"
       ],
+      "additionalProperties": false
+    },
+    "Logprob": {
+      "type": "object",
+      "properties": {
+        "token": {
+          "type": "string"
+        },
+        "logprob": {
+          "type": "number"
+        },
+        "top_logprobs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TokenLogprob"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["logprob", "token"]
+    },
+    "TokenLogprob": {
+      "type": "object",
+      "properties": {
+        "token": {
+          "type": "string"
+        },
+        "logprob": {
+          "type": "number"
+        }
+      },
+      "required": ["token", "logprob"],
       "additionalProperties": false
     },
     "AiApi": {

--- a/common/schemas/dashboard-entities.json
+++ b/common/schemas/dashboard-entities.json
@@ -10,7 +10,7 @@
         },
         "appName": {
           "type": "string",
-          "enum": ["home", "browser", "movies", "series", "iot"]
+          "enum": ["home", "browser", "movies", "series", "iot", "logging-terminal", "app-settings"]
         }
       },
       "required": ["type", "appName"],

--- a/common/schemas/dashboards-api.json
+++ b/common/schemas/dashboards-api.json
@@ -86,7 +86,7 @@
         },
         "appName": {
           "type": "string",
-          "enum": ["home", "browser", "movies", "series", "iot"]
+          "enum": ["home", "browser", "movies", "series", "iot", "logging-terminal", "app-settings"]
         }
       },
       "required": ["type", "appName"],

--- a/common/schemas/identity-api.json
+++ b/common/schemas/identity-api.json
@@ -102,36 +102,6 @@
       "required": ["result", "body"],
       "additionalProperties": false
     },
-    "PasswordResetAction": {
-      "type": "object",
-      "properties": {
-        "result": {
-          "type": "object",
-          "properties": {
-            "success": {
-              "type": "boolean"
-            }
-          },
-          "required": ["success"],
-          "additionalProperties": false
-        },
-        "body": {
-          "type": "object",
-          "properties": {
-            "currentPassword": {
-              "type": "string"
-            },
-            "newPassword": {
-              "type": "string"
-            }
-          },
-          "required": ["currentPassword", "newPassword"],
-          "additionalProperties": false
-        }
-      },
-      "required": ["result", "body"],
-      "additionalProperties": false
-    },
     "PostUserEndpoint": {
       "type": "object",
       "properties": {
@@ -188,6 +158,36 @@
         }
       },
       "required": ["roles"],
+      "additionalProperties": false
+    },
+    "PasswordResetAction": {
+      "type": "object",
+      "properties": {
+        "result": {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean"
+            }
+          },
+          "required": ["success"],
+          "additionalProperties": false
+        },
+        "body": {
+          "type": "object",
+          "properties": {
+            "currentPassword": {
+              "type": "string"
+            },
+            "newPassword": {
+              "type": "string"
+            }
+          },
+          "required": ["currentPassword", "newPassword"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["result", "body"],
       "additionalProperties": false
     },
     "IdentityApi": {

--- a/common/src/models/dashboard/app-shortcut-widget.ts
+++ b/common/src/models/dashboard/app-shortcut-widget.ts
@@ -1,4 +1,4 @@
 export interface AppShortcutWidget {
   type: 'app-shortcut'
-  appName: 'home' | 'browser' | 'movies' | 'series' | 'iot' | 'logging-terminal'
+  appName: 'home' | 'browser' | 'movies' | 'series' | 'iot' | 'logging-terminal' | 'app-settings'
 }

--- a/frontend/src/components/command-palette/command-providers/app-settings.tsx
+++ b/frontend/src/components/command-palette/command-providers/app-settings.tsx
@@ -1,0 +1,45 @@
+import { getCurrentUser } from '@furystack/core'
+import type { CommandProvider } from '@furystack/shades-common-components'
+import { navigateToRoute } from '../../../navigate-to-route.js'
+import { appSettingsRoute } from '../../routes/admin-routes.js'
+import type { SuggestionOptions } from './create-suggestion.js'
+import { createSuggestion, distinctByName } from './create-suggestion.js'
+
+const AppSettingsSuggestions: SuggestionOptions[] = [
+  {
+    name: 'Application Settings',
+    description: 'Configure application-wide settings',
+    icon: '🔧',
+    score: 1,
+    onSelected: ({ injector }) => {
+      navigateToRoute(injector, appSettingsRoute, {})
+    },
+  },
+]
+
+export const appSettingsCommandProvider: CommandProvider = async ({ term, injector }) => {
+  if (!term) {
+    return []
+  }
+
+  if (!(await getCurrentUser(injector))?.roles?.includes('admin')) {
+    return []
+  }
+
+  const fullHits = AppSettingsSuggestions.filter((c) => c.name.toLowerCase() === term.toLowerCase()).map((c) =>
+    createSuggestion({ ...c, score: 1 }),
+  )
+  const startsWith = AppSettingsSuggestions.filter((c) => c.name.toLowerCase().startsWith(term.toLowerCase())).map(
+    (c) => createSuggestion({ ...c, score: 2 }),
+  )
+
+  const contains = AppSettingsSuggestions.filter((c) => c.name.toLowerCase().includes(term.toLowerCase())).map((c) =>
+    createSuggestion({ ...c, score: 3 }),
+  )
+
+  const descriptionContains = AppSettingsSuggestions.filter((c) =>
+    c.description.toLowerCase().includes(term.toLowerCase()),
+  ).map((c) => createSuggestion({ ...c, score: 2 }))
+
+  return distinctByName(...fullHits, ...startsWith, ...contains, ...descriptionContains)
+}

--- a/frontend/src/components/command-palette/index.tsx
+++ b/frontend/src/components/command-palette/index.tsx
@@ -1,10 +1,11 @@
 import { Shade, createComponent } from '@furystack/shades'
 import { CommandPalette } from '@furystack/shades-common-components'
+import { appSettingsCommandProvider } from './command-providers/app-settings.js'
 import { browserCommandProvider } from './command-providers/browser.js'
-import { entitiesCommandProvider } from './command-providers/entities.js'
 import { continueWatchingCommandProvider } from './command-providers/continue-watching.js'
-import { searchSeriesCommandProvider } from './command-providers/search-series.js'
+import { entitiesCommandProvider } from './command-providers/entities.js'
 import { searchMovieCommandProvider } from './command-providers/search-movie.js'
+import { searchSeriesCommandProvider } from './command-providers/search-series.js'
 
 export const PiRatCommandPalette = Shade({
   shadowDomName: 'pirat-command-palette',
@@ -12,11 +13,12 @@ export const PiRatCommandPalette = Shade({
     return (
       <CommandPalette
         commandProviders={[
+          appSettingsCommandProvider,
           browserCommandProvider,
-          entitiesCommandProvider,
           continueWatchingCommandProvider,
-          searchSeriesCommandProvider,
+          entitiesCommandProvider,
           searchMovieCommandProvider,
+          searchSeriesCommandProvider,
         ]}
         defaultPrefix=">"
       />

--- a/frontend/src/components/dashboard/app-shortcut-widget.tsx
+++ b/frontend/src/components/dashboard/app-shortcut-widget.tsx
@@ -1,5 +1,6 @@
 import { Shade, createComponent } from '@furystack/shades'
 import type { AppShortcutWidget as AppShortcutWidgetData } from 'common'
+import { appSettingsRoute } from '../routes/admin-routes.js'
 import { defaultDashboardRoute } from '../routes/dashboard-routes.js'
 import { fileBrowserRoute } from '../routes/file-browser-routes.js'
 import { iotDeviceListRoute } from '../routes/iot-routes.js'
@@ -23,6 +24,8 @@ export const AppShortcutWidget = Shade<AppShortcutWidgetData>({
         return <IconUrlWidget {...rest} name="IOT Devices" url={iotDeviceListRoute.url} icon={<>📡</>} />
       case 'logging-terminal':
         return <IconUrlWidget {...rest} name="Logging Terminal" url={LogEntriesTerminalRoute.url} icon={<>💻</>} />
+      case 'app-settings':
+        return <IconUrlWidget {...rest} name="Application Settings" url={appSettingsRoute.url} icon={<>🔧</>} />
       default:
         return <IconUrlWidget {...rest} name={appName} url={`/${appName}`} icon={<>🚫</>} />
     }

--- a/frontend/src/components/routes/admin-routes.tsx
+++ b/frontend/src/components/routes/admin-routes.tsx
@@ -18,4 +18,20 @@ export const adminSettingsRoute = {
   },
 } satisfies Route<unknown>
 
-export const adminRoutes = [adminSettingsRoute] as const
+export const appSettingsRoute = {
+  url: '/app-settings',
+  onVisit,
+  onLeave,
+  component: () => {
+    return (
+      <PiRatLazyLoad
+        component={async () => {
+          const { AppSettingsPage } = await import('../../pages/admin/app-settings.js')
+          return <AppSettingsPage />
+        }}
+      />
+    )
+  },
+} satisfies Route<unknown>
+
+export const adminRoutes = [adminSettingsRoute, appSettingsRoute] as const

--- a/frontend/src/components/user-avatar-menu.tsx
+++ b/frontend/src/components/user-avatar-menu.tsx
@@ -24,6 +24,15 @@ export const UserAvatarMenu = Shade({
       setIsMenuOpen(false)
     }
 
+    const handleAppSettingsClick = () => {
+      const appSettingsRoute: Route<Record<string, never>> = {
+        url: '/app-settings',
+        component: () => <div>Loading...</div>,
+      }
+      navigateToRoute(injector, appSettingsRoute, {})
+      setIsMenuOpen(false)
+    }
+
     const handleSettingsClick = () => {
       // Navigate to user settings - defining inline to avoid import issues
       const userSettingsRoute: Route<Record<string, never>> = {
@@ -86,6 +95,23 @@ export const UserAvatarMenu = Shade({
                   }}
                 >
                   ⚙️ Admin Settings
+                </Button>
+              )}
+
+              {isAdmin && (
+                <Button
+                  onclick={handleAppSettingsClick}
+                  style={{
+                    width: '100%',
+                    justifyContent: 'flex-start',
+                    padding: '8px 12px',
+                    fontSize: '14px',
+                    background: 'transparent',
+                    border: 'none',
+                    color: 'var(--theme-text-primary)',
+                  }}
+                >
+                  🔧 Application Settings
                 </Button>
               )}
 

--- a/frontend/src/pages/admin/app-settings.tsx
+++ b/frontend/src/pages/admin/app-settings.tsx
@@ -1,0 +1,32 @@
+import { createComponent, Shade } from '@furystack/shades'
+import { Paper } from '@furystack/shades-common-components'
+
+export const AppSettingsPage = Shade({
+  shadowDomName: 'app-settings-page',
+  render: () => {
+    return (
+      <div
+        style={{
+          padding: '48px',
+          maxWidth: '800px',
+          margin: '0 auto',
+        }}
+      >
+        <h1
+          style={{
+            marginBottom: '32px',
+            color: 'var(--theme-text-primary)',
+            borderBottom: '2px solid var(--theme-primary-main)',
+            paddingBottom: '8px',
+          }}
+        >
+          Application Settings
+        </h1>
+
+        <Paper elevation={1} style={{ padding: '24px' }}>
+          <p style={{ color: 'var(--theme-text-secondary)' }}>Application settings will be available here.</p>
+        </Paper>
+      </div>
+    )
+  },
+})


### PR DESCRIPTION
## 🔧 Application Settings Page

### ✨ Features
- Added new Application Settings admin page (`/app-settings`)
- Integrated with avatar menu for quick admin access
- Added command palette support for searchable navigation
- Added app shortcut widget type for dashboard integration

### 📚 Documentation
- Updated FRONTEND_PATTERNS.mdc with UI Feature Entry Points section
- Added entry point checklist to README.md for new feature development

### 🔄 Schema Updates
- Extended `AppShortcutWidget.appName` type to include `app-settings`
- Updated dashboard schemas with `logging-terminal` and `app-settings` options
- Added AI API schema support for logprobs fields
