### PR TITLE
test: usings and injector disposal consolidations

### DIFF
--- a/.yarn/changelogs/frontend.ce1f3a54.md
+++ b/.yarn/changelogs/frontend.ce1f3a54.md
@@ -1,4 +1,5 @@
 <!-- version-type: patch -->
+
 # frontend
 
 <!--

--- a/.yarn/changelogs/frontend.ce1f3a54.md
+++ b/.yarn/changelogs/frontend.ce1f3a54.md
@@ -1,0 +1,22 @@
+<!-- version-type: patch -->
+# frontend
+
+<!--
+FORMATTING GUIDE:
+
+### Detailed Entry (appears first when merging)
+
+Use h3 (###) and below for detailed entries with paragraphs, code examples, and lists.
+
+### Simple List Items
+
+- Simple changes can be added as list items
+- They are collected together at the bottom of each section
+
+TIP: When multiple changelog drafts are merged, heading-based entries
+appear before simple list items within each section.
+-->
+
+## 🧪 Tests
+
+- Wrapped `Injector` instances in `usingAsync()` across component and service tests to ensure proper disposal after each test case, preventing potential resource leaks between tests

--- a/.yarn/versions/ce1f3a54.yml
+++ b/.yarn/versions/ce1f3a54.yml
@@ -1,0 +1,5 @@
+releases:
+  frontend: patch
+
+declined:
+  - pi-rat

--- a/frontend/src/components/Separator.spec.tsx
+++ b/frontend/src/components/Separator.spec.tsx
@@ -1,5 +1,6 @@
 import { Injector } from '@furystack/inject'
 import { createComponent, initializeShadeRoot } from '@furystack/shades'
+import { usingAsync } from '@furystack/utils'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { Separator } from './Separator.js'
 
@@ -12,31 +13,33 @@ describe('Separator', () => {
     document.body.innerHTML = ''
   })
 
-  it('should render with correct shadow DOM name', () => {
-    const injector = new Injector()
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render with correct shadow DOM name', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <Separator />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <Separator />,
+      })
+
+      const separator = rootElement.querySelector('shade-app-separator')
+      expect(separator).toBeTruthy()
     })
-
-    const separator = rootElement.querySelector('shade-app-separator')
-    expect(separator).toBeTruthy()
   })
 
-  it('should render as empty component', () => {
-    const injector = new Injector()
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render as empty component', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <Separator />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <Separator />,
+      })
+
+      const separator = rootElement.querySelector('shade-app-separator')
+      expect(separator?.textContent?.trim()).toBe('')
     })
-
-    const separator = rootElement.querySelector('shade-app-separator')
-    expect(separator?.textContent?.trim()).toBe('')
   })
 })

--- a/frontend/src/components/dashboard/widget.spec.tsx
+++ b/frontend/src/components/dashboard/widget.spec.tsx
@@ -1,5 +1,6 @@
 import { Injector } from '@furystack/inject'
 import { createComponent, initializeShadeRoot } from '@furystack/shades'
+import { usingAsync } from '@furystack/utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { Widget } from './widget.js'
@@ -20,141 +21,149 @@ describe('Widget', () => {
     vi.useRealTimers()
   })
 
-  it('should render AppShortcutWidget for app-shortcut type', () => {
-    const injector = new Injector()
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render AppShortcutWidget for app-shortcut type', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <Widget type="app-shortcut" appName="home" />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <Widget type="app-shortcut" appName="home" />,
+      })
+
+      const widget = document.querySelector('pi-rat-widget')
+      expect(widget).toBeTruthy()
+
+      const appShortcut = widget?.querySelector('pi-rat-app-shortcut-widget')
+      expect(appShortcut).toBeTruthy()
     })
-
-    const widget = document.querySelector('pi-rat-widget')
-    expect(widget).toBeTruthy()
-
-    const appShortcut = widget?.querySelector('pi-rat-app-shortcut-widget')
-    expect(appShortcut).toBeTruthy()
   })
 
-  it('should render EntityShortcutWidget for entity-shortcut type', () => {
-    const injector = new Injector()
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render EntityShortcutWidget for entity-shortcut type', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <Widget type="entity-shortcut" entityName="movie" />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <Widget type="entity-shortcut" entityName="movie" />,
+      })
+
+      const widget = document.querySelector('pi-rat-widget')
+      expect(widget).toBeTruthy()
+
+      const entityShortcut = widget?.querySelector('pi-rat-entity-shortcut-widget')
+      expect(entityShortcut).toBeTruthy()
     })
-
-    const widget = document.querySelector('pi-rat-widget')
-    expect(widget).toBeTruthy()
-
-    const entityShortcut = widget?.querySelector('pi-rat-entity-shortcut-widget')
-    expect(entityShortcut).toBeTruthy()
   })
 
-  it('should render HtmlWidget for html type', () => {
-    const injector = new Injector()
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render HtmlWidget for html type', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <Widget type="html" content="<p>Hello World</p>" />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <Widget type="html" content="<p>Hello World</p>" />,
+      })
+
+      const widget = document.querySelector('pi-rat-widget')
+      expect(widget).toBeTruthy()
+
+      const htmlWidget = widget?.querySelector('pi-rat-html-widget')
+      expect(htmlWidget).toBeTruthy()
+      expect(htmlWidget?.innerHTML).toContain('Hello World')
     })
-
-    const widget = document.querySelector('pi-rat-widget')
-    expect(widget).toBeTruthy()
-
-    const htmlWidget = widget?.querySelector('pi-rat-html-widget')
-    expect(htmlWidget).toBeTruthy()
-    expect(htmlWidget?.innerHTML).toContain('Hello World')
   })
 
-  it('should render MarkdownWidget for markdown type', () => {
-    const injector = new Injector()
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render MarkdownWidget for markdown type', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <Widget type="markdown" content="# Heading" />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <Widget type="markdown" content="# Heading" />,
+      })
+
+      const widget = document.querySelector('pi-rat-widget')
+      expect(widget).toBeTruthy()
+
+      const markdownWidget = widget?.querySelector('pi-rat-markdown-widget')
+      expect(markdownWidget).toBeTruthy()
     })
-
-    const widget = document.querySelector('pi-rat-widget')
-    expect(widget).toBeTruthy()
-
-    const markdownWidget = widget?.querySelector('pi-rat-markdown-widget')
-    expect(markdownWidget).toBeTruthy()
   })
 
-  it('should render WidgetGroup for group type', () => {
-    const injector = new Injector()
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render WidgetGroup for group type', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <Widget type="group" title="Test Group" widgets={[]} />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <Widget type="group" title="Test Group" widgets={[]} />,
+      })
+
+      const widget = document.querySelector('pi-rat-widget')
+      expect(widget).toBeTruthy()
+
+      const widgetGroup = widget?.querySelector('pi-rat-widget-group')
+      expect(widgetGroup).toBeTruthy()
     })
-
-    const widget = document.querySelector('pi-rat-widget')
-    expect(widget).toBeTruthy()
-
-    const widgetGroup = widget?.querySelector('pi-rat-widget-group')
-    expect(widgetGroup).toBeTruthy()
   })
 
-  it('should render MovieWidget for movie type', () => {
-    const injector = new Injector()
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render MovieWidget for movie type', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <Widget type="movie" imdbId="tt1234567" />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <Widget type="movie" imdbId="tt1234567" />,
+      })
+
+      const widget = document.querySelector('pi-rat-widget')
+      expect(widget).toBeTruthy()
+
+      const movieWidget = widget?.querySelector('pi-rat-movie-widget')
+      expect(movieWidget).toBeTruthy()
     })
-
-    const widget = document.querySelector('pi-rat-widget')
-    expect(widget).toBeTruthy()
-
-    const movieWidget = widget?.querySelector('pi-rat-movie-widget')
-    expect(movieWidget).toBeTruthy()
   })
 
-  it('should render SeriesWidget for series type', () => {
-    const injector = new Injector()
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render SeriesWidget for series type', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <Widget type="series" imdbId="tt7654321" />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <Widget type="series" imdbId="tt7654321" />,
+      })
+
+      const widget = document.querySelector('pi-rat-widget')
+      expect(widget).toBeTruthy()
+
+      const seriesWidget = widget?.querySelector('pi-rat-series-widget')
+      expect(seriesWidget).toBeTruthy()
     })
-
-    const widget = document.querySelector('pi-rat-widget')
-    expect(widget).toBeTruthy()
-
-    const seriesWidget = widget?.querySelector('pi-rat-series-widget')
-    expect(seriesWidget).toBeTruthy()
   })
 
-  it('should render ContinueWatchingWidgetGroup for continue-watching type', () => {
-    const injector = new Injector()
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render ContinueWatchingWidgetGroup for continue-watching type', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <Widget type="continue-watching" />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <Widget type="continue-watching" />,
+      })
+
+      const widget = document.querySelector('pi-rat-widget')
+      expect(widget).toBeTruthy()
+
+      const continueWatching = widget?.querySelector('continue-watching-widget-group')
+      expect(continueWatching).toBeTruthy()
     })
-
-    const widget = document.querySelector('pi-rat-widget')
-    expect(widget).toBeTruthy()
-
-    const continueWatching = widget?.querySelector('continue-watching-widget-group')
-    expect(continueWatching).toBeTruthy()
   })
 
   // Note: DeviceAvailability widget test is skipped because it requires complex

--- a/frontend/src/components/error-404.spec.tsx
+++ b/frontend/src/components/error-404.spec.tsx
@@ -1,10 +1,10 @@
 import { Injector } from '@furystack/inject'
 import { createComponent, initializeShadeRoot, ScreenService } from '@furystack/shades'
 import { ThemeProviderService } from '@furystack/shades-common-components'
-import { ObservableValue } from '@furystack/utils'
+import { ObservableValue, usingAsync } from '@furystack/utils'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { Error404 } from './error-404.js'
 import { darkTheme } from '../themes/dark.js'
+import { Error404 } from './error-404.js'
 
 const createMockScreenService = () => {
   return {
@@ -35,69 +35,73 @@ describe('Error404', () => {
     document.body.innerHTML = ''
   })
 
-  it('should render with correct shadow DOM name', () => {
-    const injector = new Injector()
-    injector.setExplicitInstance(createMockScreenService(), ScreenService)
-    injector.setExplicitInstance(createMockThemeProviderService(), ThemeProviderService)
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render with correct shadow DOM name', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      injector.setExplicitInstance(createMockScreenService(), ScreenService)
+      injector.setExplicitInstance(createMockThemeProviderService(), ThemeProviderService)
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <Error404 />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <Error404 />,
+      })
+
+      const error404 = rootElement.querySelector('shade-404-not-found')
+      expect(error404).toBeTruthy()
     })
-
-    const error404 = rootElement.querySelector('shade-404-not-found')
-    expect(error404).toBeTruthy()
   })
 
-  it('should display 404 error message', () => {
-    const injector = new Injector()
-    injector.setExplicitInstance(createMockScreenService(), ScreenService)
-    injector.setExplicitInstance(createMockThemeProviderService(), ThemeProviderService)
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should display 404 error message', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      injector.setExplicitInstance(createMockScreenService(), ScreenService)
+      injector.setExplicitInstance(createMockThemeProviderService(), ThemeProviderService)
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <Error404 />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <Error404 />,
+      })
+
+      const error404 = rootElement.querySelector('shade-404-not-found')
+      expect(error404?.textContent).toContain('The page you are looking for is not exists')
     })
-
-    const error404 = rootElement.querySelector('shade-404-not-found')
-    expect(error404?.textContent).toContain('The page you are looking for is not exists')
   })
 
-  it('should display helpful suggestions', () => {
-    const injector = new Injector()
-    injector.setExplicitInstance(createMockScreenService(), ScreenService)
-    injector.setExplicitInstance(createMockThemeProviderService(), ThemeProviderService)
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should display helpful suggestions', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      injector.setExplicitInstance(createMockScreenService(), ScreenService)
+      injector.setExplicitInstance(createMockThemeProviderService(), ThemeProviderService)
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <Error404 />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <Error404 />,
+      })
+
+      const error404 = rootElement.querySelector('shade-404-not-found')
+      expect(error404?.textContent).toContain('The URL above is correct')
+      expect(error404?.textContent).toContain('You have logged in')
+      expect(error404?.textContent).toContain('You have the neccessary permissions')
     })
-
-    const error404 = rootElement.querySelector('shade-404-not-found')
-    expect(error404?.textContent).toContain('The URL above is correct')
-    expect(error404?.textContent).toContain('You have logged in')
-    expect(error404?.textContent).toContain('You have the neccessary permissions')
   })
 
-  it('should render GenericErrorPage component', () => {
-    const injector = new Injector()
-    injector.setExplicitInstance(createMockScreenService(), ScreenService)
-    injector.setExplicitInstance(createMockThemeProviderService(), ThemeProviderService)
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render GenericErrorPage component', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      injector.setExplicitInstance(createMockScreenService(), ScreenService)
+      injector.setExplicitInstance(createMockThemeProviderService(), ThemeProviderService)
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <Error404 />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <Error404 />,
+      })
+
+      const genericErrorPage = rootElement.querySelector('multiverse-generic-error-page')
+      expect(genericErrorPage).toBeTruthy()
     })
-
-    const genericErrorPage = rootElement.querySelector('multiverse-generic-error-page')
-    expect(genericErrorPage).toBeTruthy()
   })
 })

--- a/frontend/src/components/role-tag/index.spec.tsx
+++ b/frontend/src/components/role-tag/index.spec.tsx
@@ -1,5 +1,6 @@
 import { Injector } from '@furystack/inject'
 import { createComponent, initializeShadeRoot } from '@furystack/shades'
+import { usingAsync } from '@furystack/utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { RoleTag } from './index.js'
@@ -14,251 +15,265 @@ describe('RoleTag', () => {
   })
 
   describe('rendering', () => {
-    it('should render with role display name', () => {
-      const injector = new Injector()
-      const rootElement = document.getElementById('root') as HTMLDivElement
+    it('should render with role display name', async () => {
+      await usingAsync(new Injector(), async (injector) => {
+        const rootElement = document.getElementById('root') as HTMLDivElement
 
-      initializeShadeRoot({
-        injector,
-        rootElement,
-        jsxElement: <RoleTag roleName="admin" variant="default" />,
+        initializeShadeRoot({
+          injector,
+          rootElement,
+          jsxElement: <RoleTag roleName="admin" variant="default" />,
+        })
+
+        const roleTag = document.querySelector('role-tag')
+        expect(roleTag).toBeTruthy()
+        expect(roleTag?.textContent).toContain('Application Admin')
       })
-
-      const roleTag = document.querySelector('role-tag')
-      expect(roleTag).toBeTruthy()
-      expect(roleTag?.textContent).toContain('Application Admin')
     })
 
-    it('should render media-manager role with correct display name', () => {
-      const injector = new Injector()
-      const rootElement = document.getElementById('root') as HTMLDivElement
+    it('should render media-manager role with correct display name', async () => {
+      await usingAsync(new Injector(), async (injector) => {
+        const rootElement = document.getElementById('root') as HTMLDivElement
 
-      initializeShadeRoot({
-        injector,
-        rootElement,
-        jsxElement: <RoleTag roleName="media-manager" variant="default" />,
+        initializeShadeRoot({
+          injector,
+          rootElement,
+          jsxElement: <RoleTag roleName="media-manager" variant="default" />,
+        })
+
+        const roleTag = document.querySelector('role-tag')
+        expect(roleTag?.textContent).toContain('Media Manager')
       })
-
-      const roleTag = document.querySelector('role-tag')
-      expect(roleTag?.textContent).toContain('Media Manager')
     })
 
-    it('should render viewer role with correct display name', () => {
-      const injector = new Injector()
-      const rootElement = document.getElementById('root') as HTMLDivElement
+    it('should render viewer role with correct display name', async () => {
+      await usingAsync(new Injector(), async (injector) => {
+        const rootElement = document.getElementById('root') as HTMLDivElement
 
-      initializeShadeRoot({
-        injector,
-        rootElement,
-        jsxElement: <RoleTag roleName="viewer" variant="default" />,
+        initializeShadeRoot({
+          injector,
+          rootElement,
+          jsxElement: <RoleTag roleName="viewer" variant="default" />,
+        })
+
+        const roleTag = document.querySelector('role-tag')
+        expect(roleTag?.textContent).toContain('Viewer')
       })
-
-      const roleTag = document.querySelector('role-tag')
-      expect(roleTag?.textContent).toContain('Viewer')
     })
 
-    it('should render iot-manager role with correct display name', () => {
-      const injector = new Injector()
-      const rootElement = document.getElementById('root') as HTMLDivElement
+    it('should render iot-manager role with correct display name', async () => {
+      await usingAsync(new Injector(), async (injector) => {
+        const rootElement = document.getElementById('root') as HTMLDivElement
 
-      initializeShadeRoot({
-        injector,
-        rootElement,
-        jsxElement: <RoleTag roleName="iot-manager" variant="default" />,
+        initializeShadeRoot({
+          injector,
+          rootElement,
+          jsxElement: <RoleTag roleName="iot-manager" variant="default" />,
+        })
+
+        const roleTag = document.querySelector('role-tag')
+        expect(roleTag?.textContent).toContain('IoT Manager')
       })
-
-      const roleTag = document.querySelector('role-tag')
-      expect(roleTag?.textContent).toContain('IoT Manager')
     })
 
-    it('should have title attribute with role description', () => {
-      const injector = new Injector()
-      const rootElement = document.getElementById('root') as HTMLDivElement
+    it('should have title attribute with role description', async () => {
+      await usingAsync(new Injector(), async (injector) => {
+        const rootElement = document.getElementById('root') as HTMLDivElement
 
-      initializeShadeRoot({
-        injector,
-        rootElement,
-        jsxElement: <RoleTag roleName="admin" variant="default" />,
+        initializeShadeRoot({
+          injector,
+          rootElement,
+          jsxElement: <RoleTag roleName="admin" variant="default" />,
+        })
+
+        const roleTag = document.querySelector('role-tag')
+        const span = roleTag?.querySelector('span')
+        expect(span?.getAttribute('title')).toBe('Full system access including user management and all settings')
       })
-
-      const roleTag = document.querySelector('role-tag')
-      const span = roleTag?.querySelector('span')
-      expect(span?.getAttribute('title')).toBe('Full system access including user management and all settings')
     })
   })
 
   describe('variants', () => {
-    it('should render default variant without remove or restore buttons when no handlers provided', () => {
-      const injector = new Injector()
-      const rootElement = document.getElementById('root') as HTMLDivElement
+    it('should render default variant without remove or restore buttons when no handlers provided', async () => {
+      await usingAsync(new Injector(), async (injector) => {
+        const rootElement = document.getElementById('root') as HTMLDivElement
 
-      initializeShadeRoot({
-        injector,
-        rootElement,
-        jsxElement: <RoleTag roleName="admin" variant="default" />,
+        initializeShadeRoot({
+          injector,
+          rootElement,
+          jsxElement: <RoleTag roleName="admin" variant="default" />,
+        })
+
+        const roleTag = document.querySelector('role-tag')
+        const buttons = roleTag?.querySelectorAll('button')
+        expect(buttons?.length).toBe(0)
       })
-
-      const roleTag = document.querySelector('role-tag')
-      const buttons = roleTag?.querySelectorAll('button')
-      expect(buttons?.length).toBe(0)
     })
 
-    it('should render default variant with remove button when onRemove is provided', () => {
-      const injector = new Injector()
-      const rootElement = document.getElementById('root') as HTMLDivElement
-      const onRemove = vi.fn()
+    it('should render default variant with remove button when onRemove is provided', async () => {
+      await usingAsync(new Injector(), async (injector) => {
+        const rootElement = document.getElementById('root') as HTMLDivElement
+        const onRemove = vi.fn()
 
-      initializeShadeRoot({
-        injector,
-        rootElement,
-        jsxElement: <RoleTag roleName="admin" variant="default" onRemove={onRemove} />,
+        initializeShadeRoot({
+          injector,
+          rootElement,
+          jsxElement: <RoleTag roleName="admin" variant="default" onRemove={onRemove} />,
+        })
+
+        const roleTag = document.querySelector('role-tag')
+        const removeButton = roleTag?.querySelector('button')
+        expect(removeButton).toBeTruthy()
+        expect(removeButton?.textContent).toContain('×')
+        expect(removeButton?.getAttribute('title')).toBe('Remove role')
       })
-
-      const roleTag = document.querySelector('role-tag')
-      const removeButton = roleTag?.querySelector('button')
-      expect(removeButton).toBeTruthy()
-      expect(removeButton?.textContent).toContain('×')
-      expect(removeButton?.getAttribute('title')).toBe('Remove role')
     })
 
-    it('should render added variant with remove button', () => {
-      const injector = new Injector()
-      const rootElement = document.getElementById('root') as HTMLDivElement
-      const onRemove = vi.fn()
+    it('should render added variant with remove button', async () => {
+      await usingAsync(new Injector(), async (injector) => {
+        const rootElement = document.getElementById('root') as HTMLDivElement
+        const onRemove = vi.fn()
 
-      initializeShadeRoot({
-        injector,
-        rootElement,
-        jsxElement: <RoleTag roleName="viewer" variant="added" onRemove={onRemove} />,
+        initializeShadeRoot({
+          injector,
+          rootElement,
+          jsxElement: <RoleTag roleName="viewer" variant="added" onRemove={onRemove} />,
+        })
+
+        const roleTag = document.querySelector('role-tag')
+        const removeButton = roleTag?.querySelector('button')
+        expect(removeButton).toBeTruthy()
+        expect(removeButton?.textContent).toContain('×')
       })
-
-      const roleTag = document.querySelector('role-tag')
-      const removeButton = roleTag?.querySelector('button')
-      expect(removeButton).toBeTruthy()
-      expect(removeButton?.textContent).toContain('×')
     })
 
-    it('should render removed variant with restore button', () => {
-      const injector = new Injector()
-      const rootElement = document.getElementById('root') as HTMLDivElement
-      const onRestore = vi.fn()
+    it('should render removed variant with restore button', async () => {
+      await usingAsync(new Injector(), async (injector) => {
+        const rootElement = document.getElementById('root') as HTMLDivElement
+        const onRestore = vi.fn()
 
-      initializeShadeRoot({
-        injector,
-        rootElement,
-        jsxElement: <RoleTag roleName="admin" variant="removed" onRestore={onRestore} />,
+        initializeShadeRoot({
+          injector,
+          rootElement,
+          jsxElement: <RoleTag roleName="admin" variant="removed" onRestore={onRestore} />,
+        })
+
+        const roleTag = document.querySelector('role-tag')
+        const restoreButton = roleTag?.querySelector('button')
+        expect(restoreButton).toBeTruthy()
+        expect(restoreButton?.textContent).toContain('↩')
+        expect(restoreButton?.getAttribute('title')).toBe('Restore role')
       })
-
-      const roleTag = document.querySelector('role-tag')
-      const restoreButton = roleTag?.querySelector('button')
-      expect(restoreButton).toBeTruthy()
-      expect(restoreButton?.textContent).toContain('↩')
-      expect(restoreButton?.getAttribute('title')).toBe('Restore role')
     })
 
-    it('should not render remove button for removed variant', () => {
-      const injector = new Injector()
-      const rootElement = document.getElementById('root') as HTMLDivElement
-      const onRemove = vi.fn()
-      const onRestore = vi.fn()
+    it('should not render remove button for removed variant', async () => {
+      await usingAsync(new Injector(), async (injector) => {
+        const rootElement = document.getElementById('root') as HTMLDivElement
+        const onRemove = vi.fn()
+        const onRestore = vi.fn()
 
-      initializeShadeRoot({
-        injector,
-        rootElement,
-        jsxElement: <RoleTag roleName="admin" variant="removed" onRemove={onRemove} onRestore={onRestore} />,
+        initializeShadeRoot({
+          injector,
+          rootElement,
+          jsxElement: <RoleTag roleName="admin" variant="removed" onRemove={onRemove} onRestore={onRestore} />,
+        })
+
+        const roleTag = document.querySelector('role-tag')
+        const buttons = roleTag?.querySelectorAll('button')
+        // Should only have restore button, not remove button
+        expect(buttons?.length).toBe(1)
+        expect(buttons?.[0]?.textContent).toContain('↩')
       })
-
-      const roleTag = document.querySelector('role-tag')
-      const buttons = roleTag?.querySelectorAll('button')
-      // Should only have restore button, not remove button
-      expect(buttons?.length).toBe(1)
-      expect(buttons?.[0]?.textContent).toContain('↩')
     })
   })
 
   describe('interactions', () => {
-    it('should call onRemove when remove button is clicked', () => {
-      const injector = new Injector()
-      const rootElement = document.getElementById('root') as HTMLDivElement
-      const onRemove = vi.fn()
+    it('should call onRemove when remove button is clicked', async () => {
+      await usingAsync(new Injector(), async (injector) => {
+        const rootElement = document.getElementById('root') as HTMLDivElement
+        const onRemove = vi.fn()
 
-      initializeShadeRoot({
-        injector,
-        rootElement,
-        jsxElement: <RoleTag roleName="admin" variant="default" onRemove={onRemove} />,
+        initializeShadeRoot({
+          injector,
+          rootElement,
+          jsxElement: <RoleTag roleName="admin" variant="default" onRemove={onRemove} />,
+        })
+
+        const roleTag = document.querySelector('role-tag')
+        const removeButton = roleTag?.querySelector('button') as HTMLButtonElement
+        removeButton.click()
+
+        expect(onRemove).toHaveBeenCalledTimes(1)
       })
-
-      const roleTag = document.querySelector('role-tag')
-      const removeButton = roleTag?.querySelector('button') as HTMLButtonElement
-      removeButton.click()
-
-      expect(onRemove).toHaveBeenCalledTimes(1)
     })
 
-    it('should call onRestore when restore button is clicked', () => {
-      const injector = new Injector()
-      const rootElement = document.getElementById('root') as HTMLDivElement
-      const onRestore = vi.fn()
+    it('should call onRestore when restore button is clicked', async () => {
+      await usingAsync(new Injector(), async (injector) => {
+        const rootElement = document.getElementById('root') as HTMLDivElement
+        const onRestore = vi.fn()
 
-      initializeShadeRoot({
-        injector,
-        rootElement,
-        jsxElement: <RoleTag roleName="admin" variant="removed" onRestore={onRestore} />,
+        initializeShadeRoot({
+          injector,
+          rootElement,
+          jsxElement: <RoleTag roleName="admin" variant="removed" onRestore={onRestore} />,
+        })
+
+        const roleTag = document.querySelector('role-tag')
+        const restoreButton = roleTag?.querySelector('button') as HTMLButtonElement
+        restoreButton.click()
+
+        expect(onRestore).toHaveBeenCalledTimes(1)
       })
-
-      const roleTag = document.querySelector('role-tag')
-      const restoreButton = roleTag?.querySelector('button') as HTMLButtonElement
-      restoreButton.click()
-
-      expect(onRestore).toHaveBeenCalledTimes(1)
     })
 
-    it('should stop event propagation when remove button is clicked', () => {
-      const injector = new Injector()
-      const rootElement = document.getElementById('root') as HTMLDivElement
-      const onRemove = vi.fn()
-      const parentClick = vi.fn()
+    it('should stop event propagation when remove button is clicked', async () => {
+      await usingAsync(new Injector(), async (injector) => {
+        const rootElement = document.getElementById('root') as HTMLDivElement
+        const onRemove = vi.fn()
+        const parentClick = vi.fn()
 
-      initializeShadeRoot({
-        injector,
-        rootElement,
-        jsxElement: (
-          <div onclick={parentClick}>
-            <RoleTag roleName="admin" variant="default" onRemove={onRemove} />
-          </div>
-        ),
+        initializeShadeRoot({
+          injector,
+          rootElement,
+          jsxElement: (
+            <div onclick={parentClick}>
+              <RoleTag roleName="admin" variant="default" onRemove={onRemove} />
+            </div>
+          ),
+        })
+
+        const roleTag = document.querySelector('role-tag')
+        const removeButton = roleTag?.querySelector('button') as HTMLButtonElement
+        removeButton.click()
+
+        expect(onRemove).toHaveBeenCalledTimes(1)
+        expect(parentClick).not.toHaveBeenCalled()
       })
-
-      const roleTag = document.querySelector('role-tag')
-      const removeButton = roleTag?.querySelector('button') as HTMLButtonElement
-      removeButton.click()
-
-      expect(onRemove).toHaveBeenCalledTimes(1)
-      expect(parentClick).not.toHaveBeenCalled()
     })
 
-    it('should stop event propagation when restore button is clicked', () => {
-      const injector = new Injector()
-      const rootElement = document.getElementById('root') as HTMLDivElement
-      const onRestore = vi.fn()
-      const parentClick = vi.fn()
+    it('should stop event propagation when restore button is clicked', async () => {
+      await usingAsync(new Injector(), async (injector) => {
+        const rootElement = document.getElementById('root') as HTMLDivElement
+        const onRestore = vi.fn()
+        const parentClick = vi.fn()
 
-      initializeShadeRoot({
-        injector,
-        rootElement,
-        jsxElement: (
-          <div onclick={parentClick}>
-            <RoleTag roleName="admin" variant="removed" onRestore={onRestore} />
-          </div>
-        ),
+        initializeShadeRoot({
+          injector,
+          rootElement,
+          jsxElement: (
+            <div onclick={parentClick}>
+              <RoleTag roleName="admin" variant="removed" onRestore={onRestore} />
+            </div>
+          ),
+        })
+
+        const roleTag = document.querySelector('role-tag')
+        const restoreButton = roleTag?.querySelector('button') as HTMLButtonElement
+        restoreButton.click()
+
+        expect(onRestore).toHaveBeenCalledTimes(1)
+        expect(parentClick).not.toHaveBeenCalled()
       })
-
-      const roleTag = document.querySelector('role-tag')
-      const restoreButton = roleTag?.querySelector('button') as HTMLButtonElement
-      restoreButton.click()
-
-      expect(onRestore).toHaveBeenCalledTimes(1)
-      expect(parentClick).not.toHaveBeenCalled()
     })
   })
 })

--- a/frontend/src/components/settings-sidebar/settings-menu-item.spec.tsx
+++ b/frontend/src/components/settings-sidebar/settings-menu-item.spec.tsx
@@ -1,5 +1,6 @@
 import { Injector } from '@furystack/inject'
 import { createComponent, initializeShadeRoot, LocationService } from '@furystack/shades'
+import { usingAsync } from '@furystack/utils'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { SettingsMenuItem } from './settings-menu-item.js'
@@ -13,91 +14,95 @@ describe('SettingsMenuItem', () => {
     document.body.innerHTML = ''
   })
 
-  it('should render with icon, label, and href', () => {
-    const injector = new Injector()
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render with icon, label, and href', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    history.pushState(null, '', '/other')
-    injector.getInstance(LocationService).updateState()
+      history.pushState(null, '', '/other')
+      injector.getInstance(LocationService).updateState()
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <SettingsMenuItem icon="🏠" label="Home" href="/home" />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <SettingsMenuItem icon="🏠" label="Home" href="/home" />,
+      })
+
+      const menuItem = document.querySelector('settings-menu-item')
+      expect(menuItem).toBeTruthy()
+
+      const link = menuItem?.querySelector('a')
+      expect(link).toBeTruthy()
+      expect(link?.getAttribute('href')).toBe('/home')
+      expect(link?.textContent).toContain('Home')
+      expect(link?.textContent).toContain('🏠')
     })
-
-    const menuItem = document.querySelector('settings-menu-item')
-    expect(menuItem).toBeTruthy()
-
-    const link = menuItem?.querySelector('a')
-    expect(link).toBeTruthy()
-    expect(link?.getAttribute('href')).toBe('/home')
-    expect(link?.textContent).toContain('Home')
-    expect(link?.textContent).toContain('🏠')
   })
 
-  it('should render with active state when URL matches href', () => {
-    const injector = new Injector()
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render with active state when URL matches href', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    history.pushState(null, '', '/settings')
-    injector.getInstance(LocationService).updateState()
+      history.pushState(null, '', '/settings')
+      injector.getInstance(LocationService).updateState()
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <SettingsMenuItem icon="⚙️" label="Settings" href="/settings" />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <SettingsMenuItem icon="⚙️" label="Settings" href="/settings" />,
+      })
+
+      const menuItem = document.querySelector('settings-menu-item')
+      expect(menuItem).toBeTruthy()
+
+      const link = menuItem?.querySelector('a')
+      expect(link).toBeTruthy()
+      expect(link?.getAttribute('href')).toBe('/settings')
+      expect(link?.textContent).toContain('Settings')
     })
-
-    const menuItem = document.querySelector('settings-menu-item')
-    expect(menuItem).toBeTruthy()
-
-    const link = menuItem?.querySelector('a')
-    expect(link).toBeTruthy()
-    expect(link?.getAttribute('href')).toBe('/settings')
-    expect(link?.textContent).toContain('Settings')
   })
 
-  it('should render with inactive state when URL does not match href', () => {
-    const injector = new Injector()
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render with inactive state when URL does not match href', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    history.pushState(null, '', '/other-page')
-    injector.getInstance(LocationService).updateState()
+      history.pushState(null, '', '/other-page')
+      injector.getInstance(LocationService).updateState()
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <SettingsMenuItem icon="📁" label="Files" href="/files" />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <SettingsMenuItem icon="📁" label="Files" href="/files" />,
+      })
+
+      const menuItem = document.querySelector('settings-menu-item')
+      expect(menuItem).toBeTruthy()
+
+      const link = menuItem?.querySelector('a')
+      expect(link).toBeTruthy()
+      expect(link?.getAttribute('href')).toBe('/files')
     })
-
-    const menuItem = document.querySelector('settings-menu-item')
-    expect(menuItem).toBeTruthy()
-
-    const link = menuItem?.querySelector('a')
-    expect(link).toBeTruthy()
-    expect(link?.getAttribute('href')).toBe('/files')
   })
 
-  it('should render correctly with different URLs', () => {
-    const injector = new Injector()
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render correctly with different URLs', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    history.pushState(null, '', '/something-else')
-    injector.getInstance(LocationService).updateState()
+      history.pushState(null, '', '/something-else')
+      injector.getInstance(LocationService).updateState()
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <SettingsMenuItem icon="🎬" label="Movies" href="/movies" />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <SettingsMenuItem icon="🎬" label="Movies" href="/movies" />,
+      })
+
+      const menuItem = document.querySelector('settings-menu-item')
+      expect(menuItem).toBeTruthy()
+
+      const link = menuItem?.querySelector('a')
+      expect(link).toBeTruthy()
+      expect(link?.getAttribute('href')).toBe('/movies')
+      expect(link?.textContent).toContain('Movies')
     })
-
-    const menuItem = document.querySelector('settings-menu-item')
-    expect(menuItem).toBeTruthy()
-
-    const link = menuItem?.querySelector('a')
-    expect(link).toBeTruthy()
-    expect(link?.getAttribute('href')).toBe('/movies')
-    expect(link?.textContent).toContain('Movies')
   })
 })

--- a/frontend/src/components/theme-switch/index.spec.tsx
+++ b/frontend/src/components/theme-switch/index.spec.tsx
@@ -1,10 +1,11 @@
 import { Injector } from '@furystack/inject'
 import { createComponent, initializeShadeRoot } from '@furystack/shades'
 import { ThemeProviderService } from '@furystack/shades-common-components'
+import { usingAsync } from '@furystack/utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { ThemeSwitch } from './index.js'
 import { darkTheme } from '../../themes/dark.js'
 import { lightTheme } from '../../themes/light.js'
+import { ThemeSwitch } from './index.js'
 
 const createMockThemeProviderService = (theme = darkTheme) => {
   const mockService = {
@@ -24,110 +25,117 @@ describe('ThemeSwitch', () => {
     document.body.innerHTML = ''
   })
 
-  it('should render with correct shadow DOM name', () => {
-    const injector = new Injector()
-    injector.setExplicitInstance(createMockThemeProviderService(), ThemeProviderService)
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render with correct shadow DOM name', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      injector.setExplicitInstance(createMockThemeProviderService(), ThemeProviderService)
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <ThemeSwitch />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <ThemeSwitch />,
+      })
+
+      const themeSwitch = rootElement.querySelector('theme-switch')
+      expect(themeSwitch).toBeTruthy()
     })
-
-    const themeSwitch = rootElement.querySelector('theme-switch')
-    expect(themeSwitch).toBeTruthy()
   })
 
-  it('should render with dark theme', () => {
-    const injector = new Injector()
-    injector.setExplicitInstance(createMockThemeProviderService(darkTheme), ThemeProviderService)
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render with dark theme', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      injector.setExplicitInstance(createMockThemeProviderService(darkTheme), ThemeProviderService)
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <ThemeSwitch />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <ThemeSwitch />,
+      })
+
+      const themeSwitch = rootElement.querySelector('theme-switch')
+      expect(themeSwitch).toBeTruthy()
     })
-
-    const themeSwitch = rootElement.querySelector('theme-switch')
-    expect(themeSwitch).toBeTruthy()
   })
 
-  it('should render with light theme', () => {
-    const injector = new Injector()
-    injector.setExplicitInstance(createMockThemeProviderService(lightTheme), ThemeProviderService)
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render with light theme', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      injector.setExplicitInstance(createMockThemeProviderService(lightTheme), ThemeProviderService)
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <ThemeSwitch />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <ThemeSwitch />,
+      })
+
+      const themeSwitch = rootElement.querySelector('theme-switch')
+      expect(themeSwitch).toBeTruthy()
     })
-
-    const themeSwitch = rootElement.querySelector('theme-switch')
-    expect(themeSwitch).toBeTruthy()
   })
 
-  it('should use theme provider service', () => {
-    const mockThemeProvider = createMockThemeProviderService(darkTheme)
-    const injector = new Injector()
-    injector.setExplicitInstance(mockThemeProvider, ThemeProviderService)
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should use theme provider service', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const mockThemeProvider = createMockThemeProviderService(darkTheme)
+      injector.setExplicitInstance(mockThemeProvider, ThemeProviderService)
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <ThemeSwitch />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <ThemeSwitch />,
+      })
+
+      const themeSwitch = rootElement.querySelector('theme-switch')
+      expect(themeSwitch).toBeTruthy()
     })
-
-    const themeSwitch = rootElement.querySelector('theme-switch')
-    expect(themeSwitch).toBeTruthy()
   })
 
-  it('should accept additional props', () => {
-    const mockThemeProvider = createMockThemeProviderService(lightTheme)
-    const injector = new Injector()
-    injector.setExplicitInstance(mockThemeProvider, ThemeProviderService)
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should accept additional props', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const mockThemeProvider = createMockThemeProviderService(lightTheme)
+      injector.setExplicitInstance(mockThemeProvider, ThemeProviderService)
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <ThemeSwitch />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <ThemeSwitch />,
+      })
+
+      const themeSwitch = rootElement.querySelector('theme-switch')
+      expect(themeSwitch).toBeTruthy()
     })
-
-    const themeSwitch = rootElement.querySelector('theme-switch')
-    expect(themeSwitch).toBeTruthy()
   })
 
-  it('should subscribe to theme changes', () => {
-    const mockThemeProvider = createMockThemeProviderService()
-    const injector = new Injector()
-    injector.setExplicitInstance(mockThemeProvider, ThemeProviderService)
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should subscribe to theme changes', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const mockThemeProvider = createMockThemeProviderService()
+      injector.setExplicitInstance(mockThemeProvider, ThemeProviderService)
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <ThemeSwitch />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <ThemeSwitch />,
+      })
+
+      expect(mockThemeProvider.subscribe).toHaveBeenCalledWith('themeChanged', expect.any(Function))
     })
-
-    expect(mockThemeProvider.subscribe).toHaveBeenCalledWith('themeChanged', expect.any(Function))
   })
 
-  it('should render with custom variant prop', () => {
-    const injector = new Injector()
-    injector.setExplicitInstance(createMockThemeProviderService(), ThemeProviderService)
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render with custom variant prop', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      injector.setExplicitInstance(createMockThemeProviderService(), ThemeProviderService)
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: <ThemeSwitch variant="outlined" />,
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: <ThemeSwitch variant="outlined" />,
+      })
+
+      const themeSwitch = rootElement.querySelector('theme-switch')
+      expect(themeSwitch).toBeTruthy()
     })
-
-    const themeSwitch = rootElement.querySelector('theme-switch')
-    expect(themeSwitch).toBeTruthy()
   })
 })

--- a/frontend/src/components/wizard-step.spec.tsx
+++ b/frontend/src/components/wizard-step.spec.tsx
@@ -1,6 +1,6 @@
 import { Injector } from '@furystack/inject'
 import { createComponent, initializeShadeRoot, ScreenService } from '@furystack/shades'
-import { ObservableValue } from '@furystack/utils'
+import { ObservableValue, usingAsync } from '@furystack/utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { WizardStep } from './wizard-step.js'
@@ -53,213 +53,222 @@ describe('WizardStep', () => {
     vi.useRealTimers()
   })
 
-  it('should render with title', () => {
-    const injector = new Injector()
-    injector.setExplicitInstance(createMockScreenService(), ScreenService)
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render with title', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      injector.setExplicitInstance(createMockScreenService(), ScreenService)
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: (
-        <WizardStep title="Test Step" currentPage={0} maxPages={3}>
-          <p>Step content</p>
-        </WizardStep>
-      ),
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: (
+          <WizardStep title="Test Step" currentPage={0} maxPages={3}>
+            <p>Step content</p>
+          </WizardStep>
+        ),
+      })
+
+      const wizardStep = document.querySelector('wizard-step')
+      expect(wizardStep).toBeTruthy()
+
+      const title = wizardStep?.querySelector('h1')
+      expect(title?.textContent).toBe('Test Step')
     })
-
-    const wizardStep = document.querySelector('wizard-step')
-    expect(wizardStep).toBeTruthy()
-
-    const title = wizardStep?.querySelector('h1')
-    expect(title?.textContent).toBe('Test Step')
   })
 
-  it('should render children in content area', () => {
-    const injector = new Injector()
-    injector.setExplicitInstance(createMockScreenService(), ScreenService)
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render children in content area', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      injector.setExplicitInstance(createMockScreenService(), ScreenService)
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: (
-        <WizardStep title="Content Test" currentPage={0} maxPages={2}>
-          <div id="test-content">Custom content here</div>
-        </WizardStep>
-      ),
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: (
+          <WizardStep title="Content Test" currentPage={0} maxPages={2}>
+            <div id="test-content">Custom content here</div>
+          </WizardStep>
+        ),
+      })
+
+      const wizardStep = document.querySelector('wizard-step')
+      expect(wizardStep).toBeTruthy()
+
+      const content = wizardStep?.querySelector('#test-content')
+      expect(content).toBeTruthy()
+      expect(content?.textContent).toBe('Custom content here')
     })
-
-    const wizardStep = document.querySelector('wizard-step')
-    expect(wizardStep).toBeTruthy()
-
-    const content = wizardStep?.querySelector('#test-content')
-    expect(content).toBeTruthy()
-    expect(content?.textContent).toBe('Custom content here')
   })
 
-  it('should disable Previous button on first page', () => {
-    const injector = new Injector()
-    injector.setExplicitInstance(createMockScreenService(), ScreenService)
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should disable Previous button on first page', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      injector.setExplicitInstance(createMockScreenService(), ScreenService)
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: (
-        <WizardStep title="First Page" currentPage={0} maxPages={3}>
-          Content
-        </WizardStep>
-      ),
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: (
+          <WizardStep title="First Page" currentPage={0} maxPages={3}>
+            Content
+          </WizardStep>
+        ),
+      })
+
+      vi.runAllTimers()
+
+      const wizardStep = document.querySelector('wizard-step') as Element
+      const { previousButton } = getWizardNavigationButtons(wizardStep)
+
+      expect(previousButton.disabled).toBe(true)
     })
-
-    vi.runAllTimers()
-
-    const wizardStep = document.querySelector('wizard-step') as Element
-    const { previousButton } = getWizardNavigationButtons(wizardStep)
-
-    expect(previousButton.disabled).toBe(true)
   })
 
-  it('should enable Previous button when not on first page', () => {
-    const injector = new Injector()
-    injector.setExplicitInstance(createMockScreenService(), ScreenService)
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should enable Previous button when not on first page', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      injector.setExplicitInstance(createMockScreenService(), ScreenService)
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: (
-        <WizardStep title="Second Page" currentPage={1} maxPages={3}>
-          Content
-        </WizardStep>
-      ),
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: (
+          <WizardStep title="Second Page" currentPage={1} maxPages={3}>
+            Content
+          </WizardStep>
+        ),
+      })
+
+      vi.runAllTimers()
+
+      const wizardStep = document.querySelector('wizard-step') as Element
+      const { previousButton } = getWizardNavigationButtons(wizardStep)
+
+      expect(previousButton.disabled).toBe(false)
     })
-
-    vi.runAllTimers()
-
-    const wizardStep = document.querySelector('wizard-step') as Element
-    const { previousButton } = getWizardNavigationButtons(wizardStep)
-
-    expect(previousButton.disabled).toBe(false)
   })
 
-  it('should render Next/Finish button that is enabled when not on last page', () => {
-    const injector = new Injector()
-    injector.setExplicitInstance(createMockScreenService(), ScreenService)
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render Next/Finish button that is enabled when not on last page', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      injector.setExplicitInstance(createMockScreenService(), ScreenService)
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: (
-        <WizardStep title="Middle Page" currentPage={1} maxPages={3}>
-          Content
-        </WizardStep>
-      ),
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: (
+          <WizardStep title="Middle Page" currentPage={1} maxPages={3}>
+            Content
+          </WizardStep>
+        ),
+      })
+
+      vi.runAllTimers()
+
+      const wizardStep = document.querySelector('wizard-step') as Element
+      const { nextOrFinishButton } = getWizardNavigationButtons(wizardStep)
+
+      expect(nextOrFinishButton.disabled).toBe(false)
     })
-
-    vi.runAllTimers()
-
-    const wizardStep = document.querySelector('wizard-step') as Element
-    const { nextOrFinishButton } = getWizardNavigationButtons(wizardStep)
-
-    expect(nextOrFinishButton.disabled).toBe(false)
   })
 
-  it('should render Next/Finish button on last page', () => {
-    const injector = new Injector()
-    injector.setExplicitInstance(createMockScreenService(), ScreenService)
-    const rootElement = document.getElementById('root') as HTMLDivElement
+  it('should render Next/Finish button on last page', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      injector.setExplicitInstance(createMockScreenService(), ScreenService)
+      const rootElement = document.getElementById('root') as HTMLDivElement
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: (
-        <WizardStep title="Last Page" currentPage={2} maxPages={3}>
-          Content
-        </WizardStep>
-      ),
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: (
+          <WizardStep title="Last Page" currentPage={2} maxPages={3}>
+            Content
+          </WizardStep>
+        ),
+      })
+
+      vi.runAllTimers()
+
+      const wizardStep = document.querySelector('wizard-step') as Element
+      const { nextOrFinishButton } = getWizardNavigationButtons(wizardStep)
+
+      expect(nextOrFinishButton.getAttribute('type')).toBe('submit')
     })
-
-    vi.runAllTimers()
-
-    const wizardStep = document.querySelector('wizard-step') as Element
-    const { nextOrFinishButton } = getWizardNavigationButtons(wizardStep)
-
-    expect(nextOrFinishButton.getAttribute('type')).toBe('submit')
   })
 
-  it('should call onPrev when Previous button is clicked', () => {
-    const injector = new Injector()
-    injector.setExplicitInstance(createMockScreenService(), ScreenService)
-    const rootElement = document.getElementById('root') as HTMLDivElement
-    const onPrev = vi.fn()
+  it('should call onPrev when Previous button is clicked', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      injector.setExplicitInstance(createMockScreenService(), ScreenService)
+      const rootElement = document.getElementById('root') as HTMLDivElement
+      const onPrev = vi.fn()
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: (
-        <WizardStep title="Prev Test" currentPage={1} maxPages={3} onPrev={onPrev}>
-          Content
-        </WizardStep>
-      ),
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: (
+          <WizardStep title="Prev Test" currentPage={1} maxPages={3} onPrev={onPrev}>
+            Content
+          </WizardStep>
+        ),
+      })
+
+      vi.runAllTimers()
+
+      const wizardStep = document.querySelector('wizard-step') as Element
+      const { previousButton } = getWizardNavigationButtons(wizardStep)
+
+      previousButton.click()
+      expect(onPrev).toHaveBeenCalledTimes(1)
     })
-
-    vi.runAllTimers()
-
-    const wizardStep = document.querySelector('wizard-step') as Element
-    const { previousButton } = getWizardNavigationButtons(wizardStep)
-
-    previousButton.click()
-    expect(onPrev).toHaveBeenCalledTimes(1)
   })
 
   it('should call onNext on form submit when no onSubmit provided', async () => {
-    const injector = new Injector()
-    injector.setExplicitInstance(createMockScreenService(), ScreenService)
-    const rootElement = document.getElementById('root') as HTMLDivElement
-    const onNext = vi.fn()
+    await usingAsync(new Injector(), async (injector) => {
+      injector.setExplicitInstance(createMockScreenService(), ScreenService)
+      const rootElement = document.getElementById('root') as HTMLDivElement
+      const onNext = vi.fn()
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: (
-        <WizardStep title="Next Test" currentPage={0} maxPages={3} onNext={onNext}>
-          Content
-        </WizardStep>
-      ),
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: (
+          <WizardStep title="Next Test" currentPage={0} maxPages={3} onNext={onNext}>
+            Content
+          </WizardStep>
+        ),
+      })
+
+      const wizardStep = document.querySelector('wizard-step')
+      const form = wizardStep?.querySelector('form')
+
+      form?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+      expect(onNext).toHaveBeenCalledTimes(1)
     })
-
-    const wizardStep = document.querySelector('wizard-step')
-    const form = wizardStep?.querySelector('form')
-
-    form?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
-    expect(onNext).toHaveBeenCalledTimes(1)
   })
 
   it('should call onSubmit on form submit when provided', async () => {
-    const injector = new Injector()
-    injector.setExplicitInstance(createMockScreenService(), ScreenService)
-    const rootElement = document.getElementById('root') as HTMLDivElement
-    const onSubmit = vi.fn()
-    const onNext = vi.fn()
+    await usingAsync(new Injector(), async (injector) => {
+      injector.setExplicitInstance(createMockScreenService(), ScreenService)
+      const rootElement = document.getElementById('root') as HTMLDivElement
+      const onSubmit = vi.fn()
+      const onNext = vi.fn()
 
-    initializeShadeRoot({
-      injector,
-      rootElement,
-      jsxElement: (
-        <WizardStep title="Submit Test" currentPage={0} maxPages={3} onSubmit={onSubmit} onNext={onNext}>
-          Content
-        </WizardStep>
-      ),
+      initializeShadeRoot({
+        injector,
+        rootElement,
+        jsxElement: (
+          <WizardStep title="Submit Test" currentPage={0} maxPages={3} onSubmit={onSubmit} onNext={onNext}>
+            Content
+          </WizardStep>
+        ),
+      })
+
+      const wizardStep = document.querySelector('wizard-step')
+      const form = wizardStep?.querySelector('form')
+
+      form?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+      expect(onNext).not.toHaveBeenCalled()
     })
-
-    const wizardStep = document.querySelector('wizard-step')
-    const form = wizardStep?.querySelector('form')
-
-    form?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
-    expect(onSubmit).toHaveBeenCalledTimes(1)
-    expect(onNext).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/pages/admin/ai-settings.spec.tsx
+++ b/frontend/src/pages/admin/ai-settings.spec.tsx
@@ -56,7 +56,8 @@ describe('AiSettingsPage', () => {
     injector.setExplicitInstance(mockNotyService as unknown as NotyService, NotyService)
   })
 
-  afterEach(() => {
+  afterEach(async () => {
+    await injector[Symbol.asyncDispose]()
     document.body.innerHTML = ''
   })
 

--- a/frontend/src/pages/admin/iot-settings.spec.tsx
+++ b/frontend/src/pages/admin/iot-settings.spec.tsx
@@ -57,7 +57,8 @@ describe('IotSettingsPage', () => {
     injector.setExplicitInstance(mockNotyService as unknown as NotyService, NotyService)
   })
 
-  afterEach(() => {
+  afterEach(async () => {
+    await injector[Symbol.asyncDispose]()
     document.body.innerHTML = ''
   })
 

--- a/frontend/src/pages/admin/user-details.spec.tsx
+++ b/frontend/src/pages/admin/user-details.spec.tsx
@@ -4,8 +4,8 @@ import { NotyService } from '@furystack/shades-common-components'
 import { ObservableValue } from '@furystack/utils'
 import type { User } from 'common'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { type CacheState, createMockUser } from '../../test-utils/user-test-helpers.js'
 import { UsersService } from '../../services/users-service.js'
+import { type CacheState, createMockUser } from '../../test-utils/user-test-helpers.js'
 import { UserDetailsPage } from './user-details.js'
 
 /**
@@ -51,7 +51,8 @@ describe('UserDetailsPage', () => {
     injector.setExplicitInstance(mockNotyService as unknown as NotyService, NotyService)
   })
 
-  afterEach(() => {
+  afterEach(async () => {
+    await injector[Symbol.asyncDispose]()
     document.body.innerHTML = ''
   })
 

--- a/frontend/src/pages/admin/user-list.spec.tsx
+++ b/frontend/src/pages/admin/user-list.spec.tsx
@@ -3,8 +3,8 @@ import { createComponent, initializeShadeRoot, LocationService } from '@furystac
 import { ObservableValue } from '@furystack/utils'
 import type { User } from 'common'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { type CacheState, createMockUser } from '../../test-utils/user-test-helpers.js'
 import { UsersService } from '../../services/users-service.js'
+import { type CacheState, createMockUser } from '../../test-utils/user-test-helpers.js'
 import { UserListPage } from './user-list.js'
 
 describe('UserListPage', () => {
@@ -41,7 +41,8 @@ describe('UserListPage', () => {
     injector.setExplicitInstance(mockUsersService as unknown as UsersService, UsersService)
   })
 
-  afterEach(() => {
+  afterEach(async () => {
+    await injector[Symbol.asyncDispose]()
     document.body.innerHTML = ''
   })
 

--- a/frontend/src/services/error-reporter.spec.ts
+++ b/frontend/src/services/error-reporter.spec.ts
@@ -1,5 +1,6 @@
 import { Injector } from '@furystack/inject'
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { usingAsync } from '@furystack/utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ErrorReporter } from './error-reporter.js'
 
 describe('ErrorReporter', () => {
@@ -16,136 +17,143 @@ describe('ErrorReporter', () => {
     window.open = originalWindowOpen
   })
 
-  it('should open GitHub issue with error details', () => {
-    const injector = new Injector()
-    const errorReporter = injector.getInstance(ErrorReporter)
+  it('should open GitHub issue with error details', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const errorReporter = injector.getInstance(ErrorReporter)
 
-    const error = new Error('Test error message')
-    error.stack = 'Error: Test error message\n  at test.ts:1:1'
+      const error = new Error('Test error message')
+      error.stack = 'Error: Test error message\n  at test.ts:1:1'
 
-    errorReporter.sendErrorReport(error)
+      errorReporter.sendErrorReport(error)
 
-    expect(windowOpenSpy).toHaveBeenCalledTimes(1)
+      expect(windowOpenSpy).toHaveBeenCalledTimes(1)
 
-    const callArg = windowOpenSpy.mock.calls[0][0] as string
-    expect(callArg).toContain('http://github.com/furystack/pi-rat/issues/new')
-    expect(callArg).toContain('title=')
-    expect(callArg).toContain(encodeURIComponent('Automated Bug Report - Test error message'))
-    expect(callArg).toContain('body=')
-    expect(callArg).toContain('labels=bug')
+      const callArg = windowOpenSpy.mock.calls[0][0] as string
+      expect(callArg).toContain('http://github.com/furystack/pi-rat/issues/new')
+      expect(callArg).toContain('title=')
+      expect(callArg).toContain(encodeURIComponent('Automated Bug Report - Test error message'))
+      expect(callArg).toContain('body=')
+      expect(callArg).toContain('labels=bug')
+    })
   })
 
-  it('should include error stack in issue body', () => {
-    const injector = new Injector()
-    const errorReporter = injector.getInstance(ErrorReporter)
+  it('should include error stack in issue body', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const errorReporter = injector.getInstance(ErrorReporter)
 
-    const error = new Error('Stack trace test')
-    error.stack = 'Error: Stack trace test\n  at function1\n  at function2'
+      const error = new Error('Stack trace test')
+      error.stack = 'Error: Stack trace test\n  at function1\n  at function2'
 
-    errorReporter.sendErrorReport(error)
+      errorReporter.sendErrorReport(error)
 
-    expect(windowOpenSpy).toHaveBeenCalledTimes(1)
+      expect(windowOpenSpy).toHaveBeenCalledTimes(1)
 
-    const callArg = windowOpenSpy.mock.calls[0][0] as string
-    const decodedBody = decodeURIComponent(callArg.split('body=')[1].split('&')[0])
+      const callArg = windowOpenSpy.mock.calls[0][0] as string
+      const decodedBody = decodeURIComponent(callArg.split('body=')[1].split('&')[0])
 
-    expect(decodedBody).toContain('Error: Stack trace test')
-    expect(decodedBody).toContain('at function1')
-    expect(decodedBody).toContain('at function2')
+      expect(decodedBody).toContain('Error: Stack trace test')
+      expect(decodedBody).toContain('at function1')
+      expect(decodedBody).toContain('at function2')
+    })
   })
 
-  it('should include custom context when provided', () => {
-    const injector = new Injector()
-    const errorReporter = injector.getInstance(ErrorReporter)
+  it('should include custom context when provided', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const errorReporter = injector.getInstance(ErrorReporter)
 
-    const error = new Error('Context test')
-    const context = 'User was trying to upload a file'
+      const error = new Error('Context test')
+      const context = 'User was trying to upload a file'
 
-    errorReporter.sendErrorReport(error, context)
+      errorReporter.sendErrorReport(error, context)
 
-    expect(windowOpenSpy).toHaveBeenCalledTimes(1)
+      expect(windowOpenSpy).toHaveBeenCalledTimes(1)
 
-    const callArg = windowOpenSpy.mock.calls[0][0] as string
-    const decodedBody = decodeURIComponent(callArg.split('body=')[1].split('&')[0])
+      const callArg = windowOpenSpy.mock.calls[0][0] as string
+      const decodedBody = decodeURIComponent(callArg.split('body=')[1].split('&')[0])
 
-    expect(decodedBody).toContain('User was trying to upload a file')
+      expect(decodedBody).toContain('User was trying to upload a file')
+    })
   })
 
-  it('should use default "none" when no context provided', () => {
-    const injector = new Injector()
-    const errorReporter = injector.getInstance(ErrorReporter)
+  it('should use default "none" when no context provided', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const errorReporter = injector.getInstance(ErrorReporter)
 
-    const error = new Error('No context test')
+      const error = new Error('No context test')
 
-    errorReporter.sendErrorReport(error)
+      errorReporter.sendErrorReport(error)
 
-    expect(windowOpenSpy).toHaveBeenCalledTimes(1)
+      expect(windowOpenSpy).toHaveBeenCalledTimes(1)
 
-    const callArg = windowOpenSpy.mock.calls[0][0] as string
-    const decodedBody = decodeURIComponent(callArg.split('body=')[1].split('&')[0])
+      const callArg = windowOpenSpy.mock.calls[0][0] as string
+      const decodedBody = decodeURIComponent(callArg.split('body=')[1].split('&')[0])
 
-    expect(decodedBody).toContain('## Additional Context')
-    expect(decodedBody).toContain('none')
+      expect(decodedBody).toContain('## Additional Context')
+      expect(decodedBody).toContain('none')
+    })
   })
 
-  it('should use custom repository when provided', () => {
-    const injector = new Injector()
-    const errorReporter = injector.getInstance(ErrorReporter)
+  it('should use custom repository when provided', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const errorReporter = injector.getInstance(ErrorReporter)
 
-    const error = new Error('Custom repo test')
-    const customRepo = 'https://github.com/custom/repo'
+      const error = new Error('Custom repo test')
+      const customRepo = 'https://github.com/custom/repo'
 
-    errorReporter.sendErrorReport(error, undefined, customRepo)
+      errorReporter.sendErrorReport(error, undefined, customRepo)
 
-    expect(windowOpenSpy).toHaveBeenCalledTimes(1)
+      expect(windowOpenSpy).toHaveBeenCalledTimes(1)
 
-    const callArg = windowOpenSpy.mock.calls[0][0] as string
-    expect(callArg).toContain('https://github.com/custom/repo/issues/new')
+      const callArg = windowOpenSpy.mock.calls[0][0] as string
+      expect(callArg).toContain('https://github.com/custom/repo/issues/new')
+    })
   })
 
-  it('should include app version, build date, and commit hash when provided', () => {
-    const injector = new Injector()
-    const errorReporter = injector.getInstance(ErrorReporter)
+  it('should include app version, build date, and commit hash when provided', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const errorReporter = injector.getInstance(ErrorReporter)
 
-    const error = new Error('Version info test')
-    const appVersion = '1.2.3'
-    const buildDate = '2024-01-15'
-    const commitHash = 'abc123def456'
+      const error = new Error('Version info test')
+      const appVersion = '1.2.3'
+      const buildDate = '2024-01-15'
+      const commitHash = 'abc123def456'
 
-    errorReporter.sendErrorReport(
-      error,
-      undefined,
-      'https://github.com/furystack/pi-rat',
-      appVersion,
-      buildDate,
-      commitHash,
-    )
+      errorReporter.sendErrorReport(
+        error,
+        undefined,
+        'https://github.com/furystack/pi-rat',
+        appVersion,
+        buildDate,
+        commitHash,
+      )
 
-    expect(windowOpenSpy).toHaveBeenCalledTimes(1)
+      expect(windowOpenSpy).toHaveBeenCalledTimes(1)
 
-    const callArg = windowOpenSpy.mock.calls[0][0] as string
-    const decodedBody = decodeURIComponent(callArg.split('body=')[1].split('&')[0])
+      const callArg = windowOpenSpy.mock.calls[0][0] as string
+      const decodedBody = decodeURIComponent(callArg.split('body=')[1].split('&')[0])
 
-    expect(decodedBody).toContain('App version: 1.2.3')
-    expect(decodedBody).toContain('Build date: 2024-01-15')
-    expect(decodedBody).toContain('https://github.com/furystack/pi-rat/commit/abc123def456')
+      expect(decodedBody).toContain('App version: 1.2.3')
+      expect(decodedBody).toContain('Build date: 2024-01-15')
+      expect(decodedBody).toContain('https://github.com/furystack/pi-rat/commit/abc123def456')
+    })
   })
 
-  it('should use default values for app version, build date, and commit hash when not provided', () => {
-    const injector = new Injector()
-    const errorReporter = injector.getInstance(ErrorReporter)
+  it('should use default values for app version, build date, and commit hash when not provided', async () => {
+    await usingAsync(new Injector(), async (injector) => {
+      const errorReporter = injector.getInstance(ErrorReporter)
 
-    const error = new Error('Default values test')
+      const error = new Error('Default values test')
 
-    errorReporter.sendErrorReport(error)
+      errorReporter.sendErrorReport(error)
 
-    expect(windowOpenSpy).toHaveBeenCalledTimes(1)
+      expect(windowOpenSpy).toHaveBeenCalledTimes(1)
 
-    const callArg = windowOpenSpy.mock.calls[0][0] as string
-    const decodedBody = decodeURIComponent(callArg.split('body=')[1].split('&')[0])
+      const callArg = windowOpenSpy.mock.calls[0][0] as string
+      const decodedBody = decodeURIComponent(callArg.split('body=')[1].split('&')[0])
 
-    expect(decodedBody).toContain('App version: Unknown')
-    expect(decodedBody).toContain('Build date: Unknown')
-    expect(decodedBody).toContain('/commit/Unknown')
+      expect(decodedBody).toContain('App version: Unknown')
+      expect(decodedBody).toContain('Build date: Unknown')
+      expect(decodedBody).toContain('/commit/Unknown')
+    })
   })
 })


### PR DESCRIPTION
## 🧪 Test hygiene: proper Injector disposal

Ensures all `Injector` instances in frontend tests are properly disposed after each test case,
preventing potential resource leaks between tests.

**Pattern 1 — `usingAsync()` wrapper** (8 files): For tests creating an injector per `it()` block,
the body is wrapped in `usingAsync(new Injector(), async (injector) => { ... })`.

**Pattern 2 — `afterEach` disposal** (4 files): For tests sharing an injector via `beforeEach`,
`await injector[Symbol.asyncDispose]()` is added to `afterEach`.

No production code was changed.
