### PR TITLE
refactor: Cache views

### DIFF
--- a/.yarn/changelogs/frontend.c3d30e7c.md
+++ b/.yarn/changelogs/frontend.c3d30e7c.md
@@ -1,0 +1,39 @@
+<!-- version-type: minor -->
+
+# frontend
+
+<!--
+FORMATTING GUIDE:
+
+### Detailed Entry (appears first when merging)
+
+Use h3 (###) and below for detailed entries with paragraphs, code examples, and lists.
+
+### Simple List Items
+
+- Simple changes can be added as list items
+- They are collected together at the bottom of each section
+
+TIP: When multiple changelog drafts are merged, heading-based entries
+appear before simple list items within each section.
+-->
+
+## ♻️ Refactoring
+
+### Migrated cache-dependent views to use the `CacheView` component
+
+Replaced manual `useObservable` subscriptions with inline `isPendingCacheResult`/`isLoadedCacheResult`/`isFailedCacheResult` branching in favor of the declarative `CacheView` component from `@furystack/shades-common-components`. Each affected view is now split into a slim wrapper that provides the cache reference and a content component that receives the resolved value via `data: CacheWithValue<T>` props. This eliminates boilerplate for loading/error states across:
+
+- Dashboard widgets (`DeviceAvailability`, `MovieWidget`, `SeriesWidget`)
+- Admin settings pages (`AiSettingsPage`, `IotSettingsPage`, `OmdbSettingsPage`, `StreamingSettingsPage`)
+- Admin user pages (`UserDetailsPage`, `UserListPage`)
+- AI chat list (`AiChatList`)
+- File browser drive selector (`DriveSelector`)
+- Movie overview (`MovieOverview`)
+- Related movies modal (`RelatedMoviesModalContent`)
+
+- Changed `ConfigService.configCache` from `private` to `public` so `CacheView` can reference it directly
+
+## ⬆️ Dependencies
+
+- Bumped `@furystack/shades-common-components` from `^13.0.1` to `^13.1.0` to use the new `CacheView` component

--- a/.yarn/changelogs/pi-rat.c3d30e7c.md
+++ b/.yarn/changelogs/pi-rat.c3d30e7c.md
@@ -1,0 +1,23 @@
+<!-- version-type: minor -->
+
+# pi-rat
+
+<!--
+FORMATTING GUIDE:
+
+### Detailed Entry (appears first when merging)
+
+Use h3 (###) and below for detailed entries with paragraphs, code examples, and lists.
+
+### Simple List Items
+
+- Simple changes can be added as list items
+- They are collected together at the bottom of each section
+
+TIP: When multiple changelog drafts are merged, heading-based entries
+appear before simple list items within each section.
+-->
+
+## ⬆️ Dependencies
+
+- Bumped `@furystack/shades-common-components` from `^13.0.1` to `^13.1.0`

--- a/.yarn/changelogs/pi-rat.c3d30e7c.md
+++ b/.yarn/changelogs/pi-rat.c3d30e7c.md
@@ -21,3 +21,4 @@ appear before simple list items within each section.
 ## ⬆️ Dependencies
 
 - Bumped `@furystack/shades-common-components` from `^13.0.1` to `^13.1.0`
+- Bumped `eslint-plugin-playwright` from `^2.7.1` to `^2.8.0`

--- a/.yarn/versions/c3d30e7c.yml
+++ b/.yarn/versions/c3d30e7c.yml
@@ -1,0 +1,3 @@
+releases:
+  frontend: minor
+  pi-rat: minor

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "@furystack/logging": "^8.0.30",
     "@furystack/rest-client-fetch": "^8.0.40",
     "@furystack/shades": "^12.2.4",
-    "@furystack/shades-common-components": "^13.0.1",
+    "@furystack/shades-common-components": "^13.1.0",
     "@furystack/shades-lottie": "^8.0.7",
     "@furystack/utils": "^8.1.10",
     "@types/node": "^25.3.2",

--- a/frontend/src/components/dashboard/device-availability.tsx
+++ b/frontend/src/components/dashboard/device-availability.tsx
@@ -1,8 +1,8 @@
-import { isFailedCacheResult, isLoadedCacheResult, isPendingCacheResult } from '@furystack/cache'
+import type { CacheWithValue } from '@furystack/cache'
 import { serializeToQueryString } from '@furystack/rest'
 import { Shade, createComponent } from '@furystack/shades'
-import { Skeleton, promisifyAnimation } from '@furystack/shades-common-components'
-import type { DeviceAvailability as DeviceAvailabilityProps } from 'common'
+import { CacheView, Skeleton, promisifyAnimation } from '@furystack/shades-common-components'
+import type { Device, DeviceAvailability as DeviceAvailabilityProps, Icon as IconType } from 'common'
 import { AppLink } from '../../app-routes.js'
 import { navigateToRoute } from '../../navigate-to-route.js'
 import { IotDevicesService } from '../../services/iot-devices-service.js'
@@ -40,131 +40,144 @@ const blur = (el: HTMLElement) => {
   )
 }
 
+const DeviceAvailabilityContent = Shade<{
+  data: CacheWithValue<Device>
+  size: number
+  icon?: IconType
+}>({
+  shadowDomName: 'pi-rat-device-availability-content',
+  render: ({ props, injector, useObservable }) => {
+    const { size } = props
+    const device = props.data.value
+
+    const [currentUser] = useObservable('currentUser', injector.getInstance(SessionService).currentUser)
+
+    return (
+      <AppLink
+        tabIndex={0}
+        title={device.name}
+        href="/iot/device/:id"
+        params={{ id: device.name }}
+        style={{
+          textDecoration: 'none',
+        }}
+      >
+        <div
+          onfocus={(ev) => focus(ev.target as HTMLElement)}
+          onblur={(ev) => blur(ev.target as HTMLElement)}
+          onmouseenter={(ev) => focus(ev.target as HTMLElement)}
+          onmouseleave={(ev) => blur(ev.target as HTMLElement)}
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            flexDirection: 'column',
+            width: `${size}px`,
+            height: `${size}px`,
+            filter: 'saturate(0.3)brightness(0.6)',
+            background: 'rgba(128,128,128,0.1)',
+            borderRadius: '4px',
+            margin: '8px',
+            overflow: 'hidden',
+            color: 'white',
+            boxShadow: 'rgba(0, 0, 0, 0.3) 1px 3px 6px',
+          }}
+        >
+          <div
+            style={{
+              position: 'absolute',
+              top: '0',
+              left: '0',
+              zIndex: '1',
+              fontSize: '1.3em',
+              width: 'calc(100% - 2em)',
+              display: 'flex',
+              margin: '1em',
+              justifyContent: 'space-between',
+            }}
+          >
+            <DeviceAvailabilityPanel {...device} />
+
+            {currentUser?.roles.includes('admin') ? (
+              <div style={{ display: 'flex' }}>
+                <div
+                  style={{ width: '16px', height: '16px', marginLeft: '1em' }}
+                  onclick={(ev) => {
+                    ev.preventDefault()
+                    ev.stopImmediatePropagation()
+                    navigateToRoute(
+                      injector,
+                      '/entities/iot-devices',
+                      {},
+                      {
+                        queryString: serializeToQueryString({
+                          gedst: { mode: 'edit', currentId: device.name },
+                        }),
+                      },
+                    )
+                  }}
+                  title="Edit device details"
+                >
+                  ✏️
+                </div>
+              </div>
+            ) : null}
+          </div>
+          <div
+            className="cover"
+            style={{
+              display: 'inline-block',
+              objectFit: 'cover',
+              width: '100%',
+              height: '100%',
+              transform: 'scale(1)',
+              verticalAlign: 'middle',
+              textAlign: 'center',
+              lineHeight: `${size * 0.8}px`,
+              fontSize: `${size / 2}px`,
+            }}
+          >
+            {props.icon ? <Icon {...props.icon} /> : null}
+          </div>
+          <div
+            style={{
+              width: 'calc(100% - 2em)',
+              overflow: 'hidden',
+              textAlign: 'center',
+              textOverflow: 'ellipsis',
+              position: 'absolute',
+              bottom: '0',
+              whiteSpace: 'nowrap',
+              padding: '1em',
+              background: 'rgba(0,0,0,0.7)',
+            }}
+          >
+            {device.name}
+          </div>
+        </div>
+      </AppLink>
+    )
+  },
+})
+
 export const DeviceAvailability = Shade<DeviceAvailabilityProps & { index?: number; size?: number }>({
   shadowDomName: 'pi-rat-device-availability-widget',
   elementBase: HTMLDivElement,
   elementBaseName: 'div',
-  render: ({ props, injector, useObservable, useHostProps }) => {
+  render: ({ props, injector, useHostProps }) => {
     useHostProps({ style: { transform: 'scale(0)' } })
     const { size = 256 } = props
 
     const iotDevices = injector.getInstance(IotDevicesService)
 
-    const [currentUser] = useObservable('currentUser', injector.getInstance(SessionService).currentUser)
-    const [device] = useObservable('movie', iotDevices.getDeviceAsObservable(props.deviceName))
-
-    if (isLoadedCacheResult(device)) {
-      return (
-        <AppLink
-          tabIndex={0}
-          title={device.value.name}
-          href="/iot/device/:id"
-          params={{ id: props.deviceName }}
-          style={{
-            textDecoration: 'none',
-          }}
-        >
-          <div
-            onfocus={(ev) => focus(ev.target as HTMLElement)}
-            onblur={(ev) => blur(ev.target as HTMLElement)}
-            onmouseenter={(ev) => focus(ev.target as HTMLElement)}
-            onmouseleave={(ev) => blur(ev.target as HTMLElement)}
-            style={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-              flexDirection: 'column',
-              width: `${size}px`,
-              height: `${size}px`,
-              filter: 'saturate(0.3)brightness(0.6)',
-              background: 'rgba(128,128,128,0.1)',
-              borderRadius: '4px',
-              margin: '8px',
-              overflow: 'hidden',
-              color: 'white',
-              boxShadow: 'rgba(0, 0, 0, 0.3) 1px 3px 6px',
-            }}
-          >
-            <div
-              style={{
-                position: 'absolute',
-                top: '0',
-                left: '0',
-                zIndex: '1',
-                fontSize: '1.3em',
-                width: 'calc(100% - 2em)',
-                display: 'flex',
-                margin: '1em',
-                justifyContent: 'space-between',
-              }}
-            >
-              <DeviceAvailabilityPanel {...device.value} />
-
-              {currentUser?.roles.includes('admin') ? (
-                <div style={{ display: 'flex' }}>
-                  <div
-                    style={{ width: '16px', height: '16px', marginLeft: '1em' }}
-                    onclick={(ev) => {
-                      ev.preventDefault()
-                      ev.stopImmediatePropagation()
-                      navigateToRoute(
-                        injector,
-                        '/entities/iot-devices',
-                        {},
-                        {
-                          queryString: serializeToQueryString({
-                            gedst: { mode: 'edit', currentId: device.value.name },
-                          }),
-                        },
-                      )
-                    }}
-                    title="Edit device details"
-                  >
-                    ✏️
-                  </div>
-                </div>
-              ) : null}
-            </div>
-            <div
-              className="cover"
-              style={{
-                display: 'inline-block',
-                objectFit: 'cover',
-                width: '100%',
-                height: '100%',
-                transform: 'scale(1)',
-                verticalAlign: 'middle',
-                textAlign: 'center',
-                lineHeight: `${size * 0.8}px`,
-                fontSize: `${size / 2}px`,
-              }}
-            >
-              {props.icon ? <Icon {...props.icon} /> : null}
-            </div>
-            <div
-              style={{
-                width: 'calc(100% - 2em)',
-                overflow: 'hidden',
-                textAlign: 'center',
-                textOverflow: 'ellipsis',
-                position: 'absolute',
-                bottom: '0',
-                whiteSpace: 'nowrap',
-                padding: '1em',
-                background: 'rgba(0,0,0,0.7)',
-              }}
-            >
-              {device.value.name}
-            </div>
-          </div>
-        </AppLink>
-      )
-    } else if (isPendingCacheResult(device)) {
-      return <Skeleton />
-    } else if (isFailedCacheResult(device)) {
-      return <>{`:(`}</>
-    }
-
-    return <>{JSON.stringify(device)}</>
+    return (
+      <CacheView
+        cache={iotDevices.deviceCache}
+        args={[props.deviceName]}
+        content={DeviceAvailabilityContent}
+        contentProps={{ size, icon: props.icon }}
+        loader={<Skeleton />}
+      />
+    )
   },
 })

--- a/frontend/src/components/dashboard/device-availability.tsx
+++ b/frontend/src/components/dashboard/device-availability.tsx
@@ -177,6 +177,7 @@ export const DeviceAvailability = Shade<DeviceAvailabilityProps & { index?: numb
         content={DeviceAvailabilityContent}
         contentProps={{ size, icon: props.icon }}
         loader={<Skeleton />}
+        error={() => <>:(</>}
       />
     )
   },

--- a/frontend/src/components/dashboard/movie-widget.tsx
+++ b/frontend/src/components/dashboard/movie-widget.tsx
@@ -1,7 +1,9 @@
-import { isFailedCacheResult, isLoadedCacheResult, isPendingCacheResult } from '@furystack/cache'
+import type { CacheWithValue } from '@furystack/cache'
+import { isLoadedCacheResult } from '@furystack/cache'
 import { serializeToQueryString } from '@furystack/rest'
 import { LazyLoad, Shade, createComponent } from '@furystack/shades'
-import { Skeleton, promisifyAnimation } from '@furystack/shades-common-components'
+import { CacheView, Skeleton, promisifyAnimation } from '@furystack/shades-common-components'
+import type { Movie } from 'common'
 import { AppLink } from '../../app-routes.js'
 import { navigateToRoute } from '../../navigate-to-route.js'
 import { MovieFilesService } from '../../services/movie-files-service.js'
@@ -39,13 +41,26 @@ const blur = (el: HTMLElement) => {
   )
 }
 
-export const MovieWidget = Shade<{
-  imdbId: string
+const MovieWidgetContent = Shade<{
+  data: CacheWithValue<Movie>
   index?: number
   size?: number
 }>({
-  shadowDomName: 'pi-rat-movie-widget',
+  shadowDomName: 'pi-rat-movie-widget-content',
   render: ({ props, injector, useObservable, useRef }) => {
+    const { size = 256 } = props
+    const movie = props.data.value
+    const { imdbId } = movie
+
+    const movieFileService = injector.getInstance(MovieFilesService)
+    const watchProgressService = injector.getInstance(WatchProgressService)
+
+    const [currentUser] = useObservable('currentUser', injector.getInstance(SessionService).currentUser)
+    const [movieFile] = useObservable(
+      'movieFile',
+      movieFileService.findMovieFileAsObservable({ filter: { imdbId: { $eq: imdbId } } }),
+    )
+
     const cardRef = useRef<HTMLElement>('card')
     setTimeout(() => {
       const el = cardRef.current
@@ -58,171 +73,167 @@ export const MovieWidget = Shade<{
         })
       }
     }, 1000)
-    const { imdbId, size = 256 } = props
 
-    const movieService = injector.getInstance(MoviesService)
-    const movieFileService = injector.getInstance(MovieFilesService)
-    const watchProgressService = injector.getInstance(WatchProgressService)
-
-    const [currentUser] = useObservable('currentUser', injector.getInstance(SessionService).currentUser)
-    const [movie] = useObservable('movie', movieService.getMovieAsObservable(imdbId))
-    const [movieFile] = useObservable(
-      'movieFile',
-      movieFileService.findMovieFileAsObservable({ filter: { imdbId: { $eq: imdbId } } }),
-    )
-
-    if (isLoadedCacheResult(movie)) {
-      return (
-        <AppLink
-          tabIndex={0}
-          title={movie.value.plot || movie.value.title}
-          href="/movies/:imdbId/overview"
-          params={{ imdbId }}
+    return (
+      <AppLink tabIndex={0} title={movie.plot || movie.title} href="/movies/:imdbId/overview" params={{ imdbId }}>
+        <div
+          onfocus={(ev) => focus(ev.target as HTMLElement)}
+          onblur={(ev) => blur(ev.target as HTMLElement)}
+          onmouseenter={(ev) => focus(ev.target as HTMLElement)}
+          onmouseleave={(ev) => blur(ev.target as HTMLElement)}
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            flexDirection: 'column',
+            width: `${size}px`,
+            height: `${size}px`,
+            filter: 'saturate(0.3)brightness(0.6)',
+            background: 'rgba(128,128,128,0.1)',
+            transform: 'scale(0)',
+            borderRadius: '4px',
+            margin: '8px',
+            overflow: 'hidden',
+            color: 'white',
+          }}
         >
           <div
-            onfocus={(ev) => focus(ev.target as HTMLElement)}
-            onblur={(ev) => blur(ev.target as HTMLElement)}
-            onmouseenter={(ev) => focus(ev.target as HTMLElement)}
-            onmouseleave={(ev) => blur(ev.target as HTMLElement)}
             style={{
+              position: 'absolute',
+              top: '0',
+              left: '0',
+              zIndex: '1',
+              fontSize: '1.3em',
+              width: 'calc(100% - 2em)',
               display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-              flexDirection: 'column',
-              width: `${size}px`,
-              height: `${size}px`,
-              filter: 'saturate(0.3)brightness(0.6)',
-              background: 'rgba(128,128,128,0.1)',
-              transform: 'scale(0)',
-              borderRadius: '4px',
-              margin: '8px',
-              overflow: 'hidden',
-              color: 'white',
+              margin: '1em',
+              justifyContent: 'space-between',
+              filter: 'drop-shadow(black 0px 0px 5px) drop-shadow(black 0px 0px 8px) drop-shadow(black 0px 0px 10px)',
             }}
           >
-            <div
-              style={{
-                position: 'absolute',
-                top: '0',
-                left: '0',
-                zIndex: '1',
-                fontSize: '1.3em',
-                width: 'calc(100% - 2em)',
-                display: 'flex',
-                margin: '1em',
-                justifyContent: 'space-between',
-                filter: 'drop-shadow(black 0px 0px 5px) drop-shadow(black 0px 0px 8px) drop-shadow(black 0px 0px 10px)',
-              }}
-            >
-              {isLoadedCacheResult(movieFile) && movieFile.value.entries[0] ? (
-                <div style={{ display: 'flex' }}>
-                  <div
-                    title="Play movie"
-                    style={{ width: '16px' }}
-                    onclick={(ev) => {
-                      ev.stopImmediatePropagation()
-                      ev.preventDefault()
-                      navigateToRoute(injector, '/movies/:id/watch', { id: movieFile.value.entries[0].id })
-                    }}
-                  >
-                    ▶️
-                  </div>
+            {isLoadedCacheResult(movieFile) && movieFile.value.entries[0] ? (
+              <div style={{ display: 'flex' }}>
+                <div
+                  title="Play movie"
+                  style={{ width: '16px' }}
+                  onclick={(ev) => {
+                    ev.stopImmediatePropagation()
+                    ev.preventDefault()
+                    navigateToRoute(injector, '/movies/:id/watch', { id: movieFile.value.entries[0].id })
+                  }}
+                >
+                  ▶️
                 </div>
-              ) : null}
+              </div>
+            ) : null}
 
-              {currentUser?.roles.includes('admin') ? (
-                <div style={{ display: 'flex' }}>
-                  <div
-                    style={{ width: '16px', height: '16px', marginLeft: '1em' }}
-                    onclick={(ev) => {
-                      ev.preventDefault()
-                      ev.stopImmediatePropagation()
-                      navigateToRoute(
-                        injector,
-                        '/entities/movies',
-                        {},
-                        {
-                          queryString: serializeToQueryString({ gedst: { mode: 'edit', currentId: imdbId } }),
-                        },
-                      )
-                    }}
-                    title="Edit movie details"
-                  >
-                    ✏️
-                  </div>
+            {currentUser?.roles.includes('admin') ? (
+              <div style={{ display: 'flex' }}>
+                <div
+                  style={{ width: '16px', height: '16px', marginLeft: '1em' }}
+                  onclick={(ev) => {
+                    ev.preventDefault()
+                    ev.stopImmediatePropagation()
+                    navigateToRoute(
+                      injector,
+                      '/entities/movies',
+                      {},
+                      {
+                        queryString: serializeToQueryString({ gedst: { mode: 'edit', currentId: imdbId } }),
+                      },
+                    )
+                  }}
+                  title="Edit movie details"
+                >
+                  ✏️
                 </div>
-              ) : null}
-            </div>
-            <img
-              src={movie.value.thumbnailImageUrl as string}
-              alt={movie.value.title}
-              className="cover"
-              style={{
-                display: 'inline-block',
-                backgroundColor: '#666',
-                objectFit: 'cover',
-                width: '100%',
-                height: '100%',
-                transform: 'scale(1)',
+              </div>
+            ) : null}
+          </div>
+          <img
+            src={movie.thumbnailImageUrl as string}
+            alt={movie.title}
+            className="cover"
+            style={{
+              display: 'inline-block',
+              backgroundColor: '#666',
+              objectFit: 'cover',
+              width: '100%',
+              height: '100%',
+              transform: 'scale(1)',
+            }}
+          />
+          <div
+            style={{
+              width: 'calc(100% - 2em)',
+              overflow: 'hidden',
+              textAlign: 'center',
+              textOverflow: 'ellipsis',
+              position: 'absolute',
+              bottom: '0',
+              whiteSpace: 'nowrap',
+              padding: '1em',
+              background: 'rgba(0,0,0,0.7)',
+            }}
+          >
+            {movie.title}
+            <LazyLoad
+              loader={<div />}
+              component={async () => {
+                if (!isLoadedCacheResult(movieFile)) {
+                  return <></>
+                }
+
+                const { entries: watchProgresses } = await watchProgressService.findWatchProgressForFile(
+                  movieFile.value.entries[0],
+                )
+
+                const lastRecentWatchProgress = watchProgresses.find((w) =>
+                  movieFile.value.entries.some((file) => file.driveLetter === w.driveLetter && file.path === w.path),
+                )
+
+                const percent =
+                  lastRecentWatchProgress &&
+                  Math.round(100 * (lastRecentWatchProgress.watchedSeconds / (movie.duration || Infinity)))
+
+                return (
+                  <div
+                    style={{
+                      position: 'absolute',
+                      bottom: '0',
+                      left: '0',
+                      height: '2px',
+                      width: `${percent}%`,
+                      background: 'rgba(96,96,255,0.5)',
+                    }}
+                  />
+                )
               }}
             />
-            <div
-              style={{
-                width: 'calc(100% - 2em)',
-                overflow: 'hidden',
-                textAlign: 'center',
-                textOverflow: 'ellipsis',
-                position: 'absolute',
-                bottom: '0',
-                whiteSpace: 'nowrap',
-                padding: '1em',
-                background: 'rgba(0,0,0,0.7)',
-              }}
-            >
-              {movie.value.title}
-              <LazyLoad
-                loader={<div />}
-                component={async () => {
-                  if (!isLoadedCacheResult(movieFile)) {
-                    return <></>
-                  }
-
-                  const { entries: watchProgresses } = await watchProgressService.findWatchProgressForFile(
-                    movieFile.value.entries[0],
-                  )
-
-                  const lastRecentWatchProgress = watchProgresses.find((w) =>
-                    movieFile.value.entries.some((file) => file.driveLetter === w.driveLetter && file.path === w.path),
-                  )
-
-                  const percent =
-                    lastRecentWatchProgress &&
-                    Math.round(100 * (lastRecentWatchProgress.watchedSeconds / (movie.value.duration || Infinity)))
-
-                  return (
-                    <div
-                      style={{
-                        position: 'absolute',
-                        bottom: '0',
-                        left: '0',
-                        height: '2px',
-                        width: `${percent}%`,
-                        background: 'rgba(96,96,255,0.5)',
-                      }}
-                    />
-                  )
-                }}
-              />
-            </div>
           </div>
-        </AppLink>
-      )
-    } else if (isPendingCacheResult(movie)) {
-      return <Skeleton />
-    } else if (isFailedCacheResult(movie)) {
-      return <>:(</>
-    }
+        </div>
+      </AppLink>
+    )
+  },
+})
 
-    return null
+export const MovieWidget = Shade<{
+  imdbId: string
+  index?: number
+  size?: number
+}>({
+  shadowDomName: 'pi-rat-movie-widget',
+  render: ({ props, injector }) => {
+    const movieService = injector.getInstance(MoviesService)
+
+    return (
+      <CacheView
+        cache={movieService.movieCache}
+        args={[props.imdbId]}
+        content={MovieWidgetContent}
+        contentProps={{ index: props.index, size: props.size }}
+        loader={<Skeleton />}
+      />
+    )
   },
 })

--- a/frontend/src/components/dashboard/movie-widget.tsx
+++ b/frontend/src/components/dashboard/movie-widget.tsx
@@ -233,6 +233,7 @@ export const MovieWidget = Shade<{
         content={MovieWidgetContent}
         contentProps={{ index: props.index, size: props.size }}
         loader={<Skeleton />}
+        error={() => <>:(</>}
       />
     )
   },

--- a/frontend/src/components/dashboard/series-widget.tsx
+++ b/frontend/src/components/dashboard/series-widget.tsx
@@ -140,6 +140,7 @@ export const SeriesWidget = Shade<{
         content={SeriesWidgetContent}
         contentProps={{ index: props.index, size: props.size }}
         loader={<Skeleton />}
+        error={() => <>:(</>}
       />
     )
   },

--- a/frontend/src/components/dashboard/series-widget.tsx
+++ b/frontend/src/components/dashboard/series-widget.tsx
@@ -1,6 +1,7 @@
-import { isFailedCacheResult, isLoadedCacheResult, isPendingCacheResult } from '@furystack/cache'
+import type { CacheWithValue } from '@furystack/cache'
 import { Shade, createComponent } from '@furystack/shades'
-import { Skeleton, promisifyAnimation } from '@furystack/shades-common-components'
+import { CacheView, Skeleton, promisifyAnimation } from '@furystack/shades-common-components'
+import type { Series } from 'common'
 import { AppLink } from '../../app-routes.js'
 import { SeriesService } from '../../services/series-service.js'
 
@@ -34,13 +35,18 @@ const blur = (el: HTMLElement) => {
   )
 }
 
-export const SeriesWidget = Shade<{
-  imdbId: string
+const SeriesWidgetContent = Shade<{
+  data: CacheWithValue<Series>
   index?: number
   size?: number
 }>({
-  shadowDomName: 'pi-rat-series-widget',
-  render: ({ props, injector, useObservable, useRef }) => {
+  shadowDomName: 'pi-rat-series-widget-content',
+  render: ({ props, useRef }) => {
+    const { size = 256 } = props
+    const series = props.data.value
+    const { imdbId } = series
+    const url = `/series/${imdbId}`
+
     const cardRef = useRef<HTMLElement>('card')
     setTimeout(() => {
       const el = cardRef.current
@@ -53,86 +59,88 @@ export const SeriesWidget = Shade<{
         })
       }
     }, 1000)
-    const { imdbId, size = 256 } = props
 
-    const seriesService = injector.getInstance(SeriesService)
-    const [series] = useObservable('movie', seriesService.getSeriesAsObservable(imdbId))
-
-    const url = `/series/${imdbId}`
-
-    if (isLoadedCacheResult(series)) {
-      return (
-        <AppLink
-          tabIndex={0}
-          title={series.value.plot || series.value.title}
-          href="/series/:imdbId"
-          params={{ imdbId }}
+    return (
+      <AppLink tabIndex={0} title={series.plot || series.title} href="/series/:imdbId" params={{ imdbId }}>
+        <div
+          onfocus={(ev) => focus(ev.target as HTMLElement)}
+          onblur={(ev) => blur(ev.target as HTMLElement)}
+          onmouseenter={(ev) => focus(ev.target as HTMLElement)}
+          onmouseleave={(ev) => blur(ev.target as HTMLElement)}
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            flexDirection: 'column',
+            width: `${size}px`,
+            height: `${size}px`,
+            filter: 'saturate(0.3)brightness(0.6)',
+            background: 'rgba(128,128,128,0.1)',
+            transform: 'scale(0)',
+            borderRadius: '4px',
+            margin: '8px',
+            overflow: 'hidden',
+            color: 'white',
+          }}
+          onclick={(ev) => {
+            if (url.startsWith('http') && new URL(url).href !== window.location.href) {
+              ev.preventDefault()
+              ev.stopImmediatePropagation()
+              window.location.replace(url)
+            }
+          }}
         >
-          <div
-            onfocus={(ev) => focus(ev.target as HTMLElement)}
-            onblur={(ev) => blur(ev.target as HTMLElement)}
-            onmouseenter={(ev) => focus(ev.target as HTMLElement)}
-            onmouseleave={(ev) => blur(ev.target as HTMLElement)}
+          <img
+            src={series.thumbnailImageUrl as string}
+            alt={series.title}
+            className="cover"
             style={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-              flexDirection: 'column',
-              width: `${size}px`,
-              height: `${size}px`,
-              filter: 'saturate(0.3)brightness(0.6)',
-              background: 'rgba(128,128,128,0.1)',
-              transform: 'scale(0)',
-              borderRadius: '4px',
-              margin: '8px',
-              overflow: 'hidden',
-              color: 'white',
+              display: 'inline-block',
+              backgroundColor: '#666',
+              objectFit: 'cover',
+              width: '100%',
+              height: '100%',
+              transform: 'scale(1)',
             }}
-            onclick={(ev) => {
-              if (url.startsWith('http') && new URL(url).href !== window.location.href) {
-                ev.preventDefault()
-                ev.stopImmediatePropagation()
-                window.location.replace(url)
-              }
+          />
+          <div
+            style={{
+              width: 'calc(100% - 2em)',
+              overflow: 'hidden',
+              textAlign: 'center',
+              textOverflow: 'ellipsis',
+              position: 'absolute',
+              bottom: '0',
+              whiteSpace: 'nowrap',
+              padding: '1em',
+              background: 'rgba(0,0,0,0.7)',
             }}
           >
-            <img
-              src={series.value.thumbnailImageUrl as string}
-              alt={series.value.title}
-              className="cover"
-              style={{
-                display: 'inline-block',
-                backgroundColor: '#666',
-                objectFit: 'cover',
-                width: '100%',
-                height: '100%',
-                transform: 'scale(1)',
-              }}
-            />
-            <div
-              style={{
-                width: 'calc(100% - 2em)',
-                overflow: 'hidden',
-                textAlign: 'center',
-                textOverflow: 'ellipsis',
-                position: 'absolute',
-                bottom: '0',
-                whiteSpace: 'nowrap',
-                padding: '1em',
-                background: 'rgba(0,0,0,0.7)',
-              }}
-            >
-              {series.value.title}
-            </div>
+            {series.title}
           </div>
-        </AppLink>
-      )
-    } else if (isPendingCacheResult(series)) {
-      return <Skeleton />
-    } else if (isFailedCacheResult(series)) {
-      return <>:(</>
-    }
+        </div>
+      </AppLink>
+    )
+  },
+})
 
-    return null
+export const SeriesWidget = Shade<{
+  imdbId: string
+  index?: number
+  size?: number
+}>({
+  shadowDomName: 'pi-rat-series-widget',
+  render: ({ props, injector }) => {
+    const seriesService = injector.getInstance(SeriesService)
+
+    return (
+      <CacheView
+        cache={seriesService.seriesCache}
+        args={[props.imdbId]}
+        content={SeriesWidgetContent}
+        contentProps={{ index: props.index, size: props.size }}
+        loader={<Skeleton />}
+      />
+    )
   },
 })

--- a/frontend/src/components/movie-file-management/related-movies-modal-content.tsx
+++ b/frontend/src/components/movie-file-management/related-movies-modal-content.tsx
@@ -1,11 +1,73 @@
-import { isLoadedCacheResult, isPendingCacheResult } from '@furystack/cache'
+import type { CacheWithValue } from '@furystack/cache'
+import type { GetCollectionResult } from '@furystack/rest'
 import { Shade, createComponent } from '@furystack/shades'
-import { Button, Skeleton } from '@furystack/shades-common-components'
-import { getFullPath, type DirectoryEntry } from 'common'
+import { Button, CacheView, Skeleton } from '@furystack/shades-common-components'
+import { getFullPath, type DirectoryEntry, type MovieFile } from 'common'
 import { MediaApiClient } from '../../services/api-clients/media-api-client.js'
 import { InstallService } from '../../services/install-service.js'
 import { MovieFilesService } from '../../services/movie-files-service.js'
 import { MovieWidget } from '../dashboard/movie-widget.js'
+
+const RelatedMoviesContent = Shade<{
+  data: CacheWithValue<GetCollectionResult<MovieFile>>
+  drive: string
+  path: string
+  file: DirectoryEntry
+}>({
+  shadowDomName: 'shade-app-related-movies-content',
+  render: ({ props, useObservable, injector }) => {
+    const { drive, path, file } = props
+    const linkedFiles = props.data
+
+    const linkedFilesService = injector.getInstance(MovieFilesService)
+
+    const [serviceStatus] = useObservable(
+      'serviceStatus',
+      injector.getInstance(InstallService).getServiceStatusAsObservable(),
+    )
+
+    if (linkedFiles.value.count === 0) {
+      return (
+        <>
+          <p>
+            No related movie is linked to this file
+            <>
+              {serviceStatus.status === 'loaded' && serviceStatus.value.services.omdb ? (
+                <Button
+                  onclick={async () => {
+                    const mediaApiClient = injector.getInstance(MediaApiClient)
+                    await mediaApiClient.call({
+                      method: 'POST',
+                      action: '/link-movie',
+                      body: {
+                        driveLetter: drive,
+                        path: getFullPath(path, file.name),
+                      },
+                    })
+                    linkedFilesService.movieFileQueryCache.obsoleteRange(() => true)
+                  }}
+                >
+                  🔗 Link movie
+                </Button>
+              ) : (
+                <Button disabled>OMDB not available</Button>
+              )}
+            </>
+          </p>
+        </>
+      )
+    }
+
+    return (
+      <>
+        {`Found ${linkedFiles.value.count} related movies`}
+        {linkedFiles.value.entries.map((linkedFile) => (
+          <MovieWidget imdbId={linkedFile.imdbId as string} />
+        ))}
+      </>
+    )
+  },
+})
 
 export const RelatedMoviesModalContent = Shade<{
   file: DirectoryEntry
@@ -13,76 +75,25 @@ export const RelatedMoviesModalContent = Shade<{
   path: string
 }>({
   shadowDomName: 'shade-app-related-movies-modal-content',
-  render: ({ useObservable, injector, props }) => {
+  render: ({ injector, props }) => {
     const { drive, path, file } = props
-
     const linkedFilesService = injector.getInstance(MovieFilesService)
-    const [linkedFiles] = useObservable(
-      'linkedFiles',
-      linkedFilesService.findMovieFileAsObservable({
-        filter: {
-          driveLetter: { $eq: drive },
-          path: { $eq: getFullPath(path, file.name) },
-        },
-      }),
-    )
-
-    const [serviceStatus] = useObservable(
-      'serviceStatus',
-      injector.getInstance(InstallService).getServiceStatusAsObservable(),
-    )
-
-    if (isPendingCacheResult(linkedFiles)) {
-      return <Skeleton />
-    }
-
-    if (isLoadedCacheResult(linkedFiles)) {
-      if (linkedFiles.value.count === 0) {
-        return (
-          <>
-            <p>
-              No related movie is linked to this file
-              <>
-                {serviceStatus.status === 'loaded' && serviceStatus.value.services.omdb ? (
-                  <Button
-                    onclick={async () => {
-                      const mediaApiClient = injector.getInstance(MediaApiClient)
-                      await mediaApiClient.call({
-                        method: 'POST',
-                        action: '/link-movie',
-                        body: {
-                          driveLetter: drive,
-                          path: getFullPath(path, file.name),
-                        },
-                      })
-                      linkedFilesService.movieFileQueryCache.obsoleteRange(() => true)
-                    }}
-                  >
-                    🔗 Link movie
-                  </Button>
-                ) : (
-                  <Button disabled>OMDB not available</Button>
-                )}
-              </>
-            </p>
-          </>
-        )
-      } else {
-        return (
-          <>
-            {`Found ${linkedFiles.value.count} related movies`}
-            {linkedFiles.value.entries.map((linkedFile) => (
-              <MovieWidget imdbId={linkedFile.imdbId as string} />
-            ))}
-          </>
-        )
-      }
-    }
 
     return (
-      <div>
-        <h1>Related movies</h1>
-      </div>
+      <CacheView
+        cache={linkedFilesService.movieFileQueryCache}
+        args={[
+          {
+            filter: {
+              driveLetter: { $eq: drive },
+              path: { $eq: getFullPath(path, file.name) },
+            },
+          },
+        ]}
+        content={RelatedMoviesContent}
+        contentProps={{ drive, path, file }}
+        loader={<Skeleton />}
+      />
     )
   },
 })

--- a/frontend/src/components/movie-file-management/related-movies-modal-content.tsx
+++ b/frontend/src/components/movie-file-management/related-movies-modal-content.tsx
@@ -93,6 +93,7 @@ export const RelatedMoviesModalContent = Shade<{
         content={RelatedMoviesContent}
         contentProps={{ drive, path, file }}
         loader={<Skeleton />}
+        error={() => <>:(</>}
       />
     )
   },

--- a/frontend/src/pages/admin/ai-settings.spec.tsx
+++ b/frontend/src/pages/admin/ai-settings.spec.tsx
@@ -1,7 +1,7 @@
+import { Cache } from '@furystack/cache'
 import { Injector } from '@furystack/inject'
 import { createComponent, flushUpdates, initializeShadeRoot } from '@furystack/shades'
 import { NotyService } from '@furystack/shades-common-components'
-import { ObservableValue } from '@furystack/utils'
 import type { Config, OllamaConfig } from 'common'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ConfigService } from '../../services/config-service.js'
@@ -16,33 +16,31 @@ const createMockOllamaConfig = (host = 'http://localhost:11434'): Config => ({
   updatedAt: new Date(),
 })
 
-type CacheState<T> =
-  | { status: 'loading' }
-  | { status: 'loaded'; value: T; updatedAt: Date }
-  | { status: 'error'; error: unknown; updatedAt: Date }
-
 describe('AiSettingsPage', () => {
   let injector: Injector
   let mockConfigService: {
-    getConfigAsObservable: ReturnType<typeof vi.fn>
+    configCache: Cache<Config, [string]>
     saveConfig: ReturnType<typeof vi.fn>
   }
   let mockNotyService: {
     emit: ReturnType<typeof vi.fn>
   }
-  let configObservable: ObservableValue<CacheState<Config>>
 
   beforeEach(() => {
     document.body.innerHTML = '<div id="root"></div>'
 
-    configObservable = new ObservableValue<CacheState<Config>>({
-      status: 'loaded',
-      value: createMockOllamaConfig(),
-      updatedAt: new Date(),
+    const configCache = new Cache<Config, [string]>({
+      capacity: 10,
+      load: vi.fn().mockResolvedValue(createMockOllamaConfig()),
+    })
+
+    configCache.setExplicitValue({
+      loadArgs: ['OLLAMA_CONFIG'],
+      value: { status: 'loaded', value: createMockOllamaConfig(), updatedAt: new Date() },
     })
 
     mockConfigService = {
-      getConfigAsObservable: vi.fn().mockReturnValue(configObservable),
+      configCache,
       saveConfig: vi.fn().mockResolvedValue(createMockOllamaConfig()),
     }
 
@@ -75,8 +73,14 @@ describe('AiSettingsPage', () => {
     expect(page?.textContent).toContain('Ollama Integration')
   })
 
-  it('should display loading state', async () => {
-    configObservable.setValue({ status: 'loading' })
+  it('should display loader when loading', async () => {
+    const neverResolvingCache = new Cache<Config, [string]>({
+      capacity: 10,
+      load: () => new Promise(() => {}),
+    })
+    mockConfigService.configCache = neverResolvingCache
+
+    injector.setExplicitInstance(mockConfigService as unknown as ConfigService, ConfigService)
 
     const rootElement = document.getElementById('root') as HTMLDivElement
 
@@ -88,7 +92,8 @@ describe('AiSettingsPage', () => {
     await flushUpdates()
 
     const page = document.querySelector('ai-settings-page')
-    expect(page?.textContent).toContain('Loading settings...')
+    const skeleton = page?.querySelector('shade-skeleton')
+    expect(skeleton).toBeTruthy()
   })
 
   it('should render the form with host input when loaded', async () => {
@@ -125,7 +130,7 @@ describe('AiSettingsPage', () => {
     expect(saveButton).toBeTruthy()
   })
 
-  it('should call ConfigService.getConfigAsObservable on render', async () => {
+  it('should use configCache on render', async () => {
     const rootElement = document.getElementById('root') as HTMLDivElement
 
     initializeShadeRoot({
@@ -135,14 +140,13 @@ describe('AiSettingsPage', () => {
     })
     await flushUpdates()
 
-    expect(mockConfigService.getConfigAsObservable).toHaveBeenCalledWith('OLLAMA_CONFIG')
+    expect(mockConfigService.configCache).toBeTruthy()
   })
 
   it('should render with empty host when config value is empty', async () => {
-    configObservable.setValue({
-      status: 'loaded',
-      value: createMockOllamaConfig(''),
-      updatedAt: new Date(),
+    mockConfigService.configCache.setExplicitValue({
+      loadArgs: ['OLLAMA_CONFIG'],
+      value: { status: 'loaded', value: createMockOllamaConfig(''), updatedAt: new Date() },
     })
 
     const rootElement = document.getElementById('root') as HTMLDivElement

--- a/frontend/src/pages/admin/ai-settings.tsx
+++ b/frontend/src/pages/admin/ai-settings.tsx
@@ -96,7 +96,9 @@ const AiSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
       }
     }
 
-    const currentValues: OllamaFormData = props.data.value ? (props.data.value.value as OllamaFormData) : { host: '' }
+    const currentValues: OllamaFormData = props.data.value.value
+      ? (props.data.value.value as OllamaFormData)
+      : { host: '' }
 
     return (
       <>

--- a/frontend/src/pages/admin/ai-settings.tsx
+++ b/frontend/src/pages/admin/ai-settings.tsx
@@ -1,7 +1,9 @@
+import type { CacheWithValue } from '@furystack/cache'
 import { createComponent, Shade } from '@furystack/shades'
-import { Button, Form, Input, NotyService, Paper } from '@furystack/shades-common-components'
+import { Button, CacheView, Form, Input, NotyService, Paper, Skeleton } from '@furystack/shades-common-components'
 import { ObservableValue } from '@furystack/utils'
-import type { OllamaConfig } from 'common'
+import type { Config, OllamaConfig } from 'common'
+import { GenericErrorPage } from '../../components/generic-error.js'
 import { ConfigService } from '../../services/config-service.js'
 
 type OllamaFormData = OllamaConfig['value']
@@ -16,45 +18,11 @@ const isValidUrl = (urlString: string): boolean => {
   }
 }
 
-export const AiSettingsPage = Shade({
-  shadowDomName: 'ai-settings-page',
-  css: {
-    '& .page-title': {
-      marginBottom: '24px',
-      color: 'var(--theme-text-primary)',
-    },
-    '& .page-description': {
-      marginBottom: '24px',
-      color: 'var(--theme-text-secondary)',
-    },
-    '& .loading-text': {
-      color: 'var(--theme-text-secondary)',
-    },
-    '& .form-field': {
-      marginBottom: '24px',
-    },
-    '& .field-hint': {
-      color: 'var(--theme-text-secondary)',
-      display: 'block',
-      marginTop: '4px',
-    },
-    '& .validation-error': {
-      color: 'var(--theme-error-main)',
-      backgroundColor: 'var(--theme-error-light)',
-      padding: '12px',
-      borderRadius: '4px',
-      marginBottom: '16px',
-    },
-    '& .form-footer': {
-      borderTop: '1px solid var(--theme-background-default)',
-      paddingTop: '16px',
-    },
-  },
-  render: ({ injector, useObservable, useDisposable }) => {
+const AiSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
+  shadowDomName: 'ai-settings-content',
+  render: ({ props, injector, useObservable, useDisposable }) => {
     const configService = injector.getInstance(ConfigService)
     const notyService = injector.getInstance(NotyService)
-
-    const [config] = useObservable('ollamaConfig', configService.getConfigAsObservable('OLLAMA_CONFIG'))
 
     const isLoadingObservable = useDisposable('isLoading', () => new ObservableValue(false))
     const [isLoading] = useObservable('isLoadingValue', isLoadingObservable)
@@ -103,27 +71,10 @@ export const AiSettingsPage = Shade({
       }
     }
 
-    if (config.status === 'loading') {
-      return (
-        <div>
-          <h2 className="page-title">🤖 Ollama Integration</h2>
-          <Paper elevation={1} style={{ padding: '24px' }}>
-            <p className="loading-text">Loading settings...</p>
-          </Paper>
-        </div>
-      )
-    }
-
-    const currentValues: OllamaFormData =
-      config.status === 'loaded' && config.value
-        ? (config.value.value as OllamaFormData)
-        : {
-            host: '',
-          }
+    const currentValues: OllamaFormData = props.data.value ? (props.data.value.value as OllamaFormData) : { host: '' }
 
     return (
-      <div>
-        <h2 className="page-title">🤖 Ollama Integration</h2>
+      <>
         <p className="page-description">Configure the connection to your Ollama server for AI-powered features.</p>
 
         <Paper elevation={1} style={{ padding: '24px' }}>
@@ -162,6 +113,55 @@ export const AiSettingsPage = Shade({
             </div>
           </Form>
         </Paper>
+      </>
+    )
+  },
+})
+
+export const AiSettingsPage = Shade({
+  shadowDomName: 'ai-settings-page',
+  css: {
+    '& .page-title': {
+      marginBottom: '24px',
+      color: 'var(--theme-text-primary)',
+    },
+    '& .page-description': {
+      marginBottom: '24px',
+      color: 'var(--theme-text-secondary)',
+    },
+    '& .form-field': {
+      marginBottom: '24px',
+    },
+    '& .field-hint': {
+      color: 'var(--theme-text-secondary)',
+      display: 'block',
+      marginTop: '4px',
+    },
+    '& .validation-error': {
+      color: 'var(--theme-error-main)',
+      backgroundColor: 'var(--theme-error-light)',
+      padding: '12px',
+      borderRadius: '4px',
+      marginBottom: '16px',
+    },
+    '& .form-footer': {
+      borderTop: '1px solid var(--theme-background-default)',
+      paddingTop: '16px',
+    },
+  },
+  render: ({ injector }) => {
+    const configService = injector.getInstance(ConfigService)
+
+    return (
+      <div>
+        <h2 className="page-title">🤖 Ollama Integration</h2>
+        <CacheView
+          cache={configService.configCache}
+          args={['OLLAMA_CONFIG']}
+          content={AiSettingsContent}
+          loader={<Skeleton />}
+          error={(err, retry) => <GenericErrorPage error={err} retry={async () => retry()} />}
+        />
       </div>
     )
   },

--- a/frontend/src/pages/admin/ai-settings.tsx
+++ b/frontend/src/pages/admin/ai-settings.tsx
@@ -20,6 +20,31 @@ const isValidUrl = (urlString: string): boolean => {
 
 const AiSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
   shadowDomName: 'ai-settings-content',
+  css: {
+    '& .page-description': {
+      marginBottom: '24px',
+      color: 'var(--theme-text-secondary)',
+    },
+    '& .form-field': {
+      marginBottom: '24px',
+    },
+    '& .field-hint': {
+      color: 'var(--theme-text-secondary)',
+      display: 'block',
+      marginTop: '4px',
+    },
+    '& .validation-error': {
+      color: 'var(--theme-error-main)',
+      backgroundColor: 'var(--theme-error-light)',
+      padding: '12px',
+      borderRadius: '4px',
+      marginBottom: '16px',
+    },
+    '& .form-footer': {
+      borderTop: '1px solid var(--theme-background-default)',
+      paddingTop: '16px',
+    },
+  },
   render: ({ props, injector, useObservable, useDisposable }) => {
     const configService = injector.getInstance(ConfigService)
     const notyService = injector.getInstance(NotyService)
@@ -124,29 +149,6 @@ export const AiSettingsPage = Shade({
     '& .page-title': {
       marginBottom: '24px',
       color: 'var(--theme-text-primary)',
-    },
-    '& .page-description': {
-      marginBottom: '24px',
-      color: 'var(--theme-text-secondary)',
-    },
-    '& .form-field': {
-      marginBottom: '24px',
-    },
-    '& .field-hint': {
-      color: 'var(--theme-text-secondary)',
-      display: 'block',
-      marginTop: '4px',
-    },
-    '& .validation-error': {
-      color: 'var(--theme-error-main)',
-      backgroundColor: 'var(--theme-error-light)',
-      padding: '12px',
-      borderRadius: '4px',
-      marginBottom: '16px',
-    },
-    '& .form-footer': {
-      borderTop: '1px solid var(--theme-background-default)',
-      paddingTop: '16px',
     },
   },
   render: ({ injector }) => {

--- a/frontend/src/pages/admin/iot-settings.spec.tsx
+++ b/frontend/src/pages/admin/iot-settings.spec.tsx
@@ -1,7 +1,7 @@
+import { Cache } from '@furystack/cache'
 import { Injector } from '@furystack/inject'
 import { createComponent, flushUpdates, initializeShadeRoot } from '@furystack/shades'
 import { NotyService } from '@furystack/shades-common-components'
-import { ObservableValue } from '@furystack/utils'
 import type { Config, IotConfig } from 'common'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ConfigService } from '../../services/config-service.js'
@@ -17,33 +17,31 @@ const createMockIotConfig = (pingIntervalMs = 30000, pingTimeoutMs = 3000): Conf
   updatedAt: new Date(),
 })
 
-type CacheState<T> =
-  | { status: 'loading' }
-  | { status: 'loaded'; value: T; updatedAt: Date }
-  | { status: 'error'; error: unknown; updatedAt: Date }
-
 describe('IotSettingsPage', () => {
   let injector: Injector
   let mockConfigService: {
-    getConfigAsObservable: ReturnType<typeof vi.fn>
+    configCache: Cache<Config, [string]>
     saveConfig: ReturnType<typeof vi.fn>
   }
   let mockNotyService: {
     emit: ReturnType<typeof vi.fn>
   }
-  let configObservable: ObservableValue<CacheState<Config>>
 
   beforeEach(() => {
     document.body.innerHTML = '<div id="root"></div>'
 
-    configObservable = new ObservableValue<CacheState<Config>>({
-      status: 'loaded',
-      value: createMockIotConfig(),
-      updatedAt: new Date(),
+    const configCache = new Cache<Config, [string]>({
+      capacity: 10,
+      load: vi.fn().mockResolvedValue(createMockIotConfig()),
+    })
+
+    configCache.setExplicitValue({
+      loadArgs: ['IOT_CONFIG'],
+      value: { status: 'loaded', value: createMockIotConfig(), updatedAt: new Date() },
     })
 
     mockConfigService = {
-      getConfigAsObservable: vi.fn().mockReturnValue(configObservable),
+      configCache,
       saveConfig: vi.fn().mockResolvedValue(createMockIotConfig()),
     }
 
@@ -76,8 +74,14 @@ describe('IotSettingsPage', () => {
     expect(page?.textContent).toContain('IOT Device Availability')
   })
 
-  it('should display loading state', async () => {
-    configObservable.setValue({ status: 'loading' })
+  it('should display loader when loading', async () => {
+    const neverResolvingCache = new Cache<Config, [string]>({
+      capacity: 10,
+      load: () => new Promise(() => {}),
+    })
+    mockConfigService.configCache = neverResolvingCache
+
+    injector.setExplicitInstance(mockConfigService as unknown as ConfigService, ConfigService)
 
     const rootElement = document.getElementById('root') as HTMLDivElement
 
@@ -89,7 +93,8 @@ describe('IotSettingsPage', () => {
     await flushUpdates()
 
     const page = document.querySelector('iot-settings-page')
-    expect(page?.textContent).toContain('Loading settings...')
+    const skeleton = page?.querySelector('shade-skeleton')
+    expect(skeleton).toBeTruthy()
   })
 
   it('should render the form with ping interval and timeout inputs when loaded', async () => {
@@ -138,7 +143,7 @@ describe('IotSettingsPage', () => {
     expect(saveButton).toBeTruthy()
   })
 
-  it('should call ConfigService.getConfigAsObservable on render', async () => {
+  it('should use configCache on render', async () => {
     const rootElement = document.getElementById('root') as HTMLDivElement
 
     initializeShadeRoot({
@@ -148,14 +153,13 @@ describe('IotSettingsPage', () => {
     })
     await flushUpdates()
 
-    expect(mockConfigService.getConfigAsObservable).toHaveBeenCalledWith('IOT_CONFIG')
+    expect(mockConfigService.configCache).toBeTruthy()
   })
 
   it('should render with custom values from config', async () => {
-    configObservable.setValue({
-      status: 'loaded',
-      value: createMockIotConfig(60000, 5000),
-      updatedAt: new Date(),
+    mockConfigService.configCache.setExplicitValue({
+      loadArgs: ['IOT_CONFIG'],
+      value: { status: 'loaded', value: createMockIotConfig(60000, 5000), updatedAt: new Date() },
     })
 
     const rootElement = document.getElementById('root') as HTMLDivElement

--- a/frontend/src/pages/admin/iot-settings.tsx
+++ b/frontend/src/pages/admin/iot-settings.tsx
@@ -1,7 +1,9 @@
+import type { CacheWithValue } from '@furystack/cache'
 import { createComponent, Shade } from '@furystack/shades'
-import { Button, Form, Input, NotyService, Paper } from '@furystack/shades-common-components'
+import { Button, CacheView, Form, Input, NotyService, Paper, Skeleton } from '@furystack/shades-common-components'
 import { ObservableValue } from '@furystack/utils'
-import type { IotConfig } from 'common'
+import type { Config, IotConfig } from 'common'
+import { GenericErrorPage } from '../../components/generic-error.js'
 import { ConfigService } from '../../services/config-service.js'
 
 type IotFormData = IotConfig['value']
@@ -13,13 +15,11 @@ const MAX_PING_TIMEOUT_MS = 60000
 const DEFAULT_PING_INTERVAL_MS = 30000
 const DEFAULT_PING_TIMEOUT_MS = 3000
 
-export const IotSettingsPage = Shade({
-  shadowDomName: 'iot-settings-page',
-  render: ({ injector, useObservable, useDisposable }) => {
+const IotSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
+  shadowDomName: 'iot-settings-content',
+  render: ({ props, injector, useObservable, useDisposable }) => {
     const configService = injector.getInstance(ConfigService)
     const notyService = injector.getInstance(NotyService)
-
-    const [config] = useObservable('iotConfig', configService.getConfigAsObservable('IOT_CONFIG'))
 
     const isLoadingObservable = useDisposable('isLoading', () => new ObservableValue(false))
     const [isLoading] = useObservable('isLoadingValue', isLoadingObservable)
@@ -82,28 +82,15 @@ export const IotSettingsPage = Shade({
       }
     }
 
-    if (config.status === 'loading') {
-      return (
-        <div>
-          <h2 style={{ marginBottom: '24px', color: 'var(--theme-text-primary)' }}>📡 IOT Device Availability</h2>
-          <Paper elevation={1} style={{ padding: '24px' }}>
-            <p style={{ color: 'var(--theme-text-secondary)' }}>Loading settings...</p>
-          </Paper>
-        </div>
-      )
-    }
-
-    const currentValues: IotFormData =
-      config.status === 'loaded' && config.value
-        ? (config.value.value as IotFormData)
-        : {
-            pingIntervalMs: DEFAULT_PING_INTERVAL_MS,
-            pingTimeoutMs: DEFAULT_PING_TIMEOUT_MS,
-          }
+    const currentValues: IotFormData = props.data.value
+      ? (props.data.value.value as IotFormData)
+      : {
+          pingIntervalMs: DEFAULT_PING_INTERVAL_MS,
+          pingTimeoutMs: DEFAULT_PING_TIMEOUT_MS,
+        }
 
     return (
-      <div>
-        <h2 style={{ marginBottom: '24px', color: 'var(--theme-text-primary)' }}>📡 IOT Device Availability</h2>
+      <>
         <p style={{ marginBottom: '24px', color: 'var(--theme-text-secondary)' }}>
           Configure how frequently IOT devices are pinged to check their availability.
         </p>
@@ -175,6 +162,26 @@ export const IotSettingsPage = Shade({
             </div>
           </Form>
         </Paper>
+      </>
+    )
+  },
+})
+
+export const IotSettingsPage = Shade({
+  shadowDomName: 'iot-settings-page',
+  render: ({ injector }) => {
+    const configService = injector.getInstance(ConfigService)
+
+    return (
+      <div>
+        <h2 style={{ marginBottom: '24px', color: 'var(--theme-text-primary)' }}>📡 IOT Device Availability</h2>
+        <CacheView
+          cache={configService.configCache}
+          args={['IOT_CONFIG']}
+          content={IotSettingsContent}
+          loader={<Skeleton />}
+          error={(err, retry) => <GenericErrorPage error={err} retry={async () => retry()} />}
+        />
       </div>
     )
   },

--- a/frontend/src/pages/admin/iot-settings.tsx
+++ b/frontend/src/pages/admin/iot-settings.tsx
@@ -82,7 +82,7 @@ const IotSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
       }
     }
 
-    const currentValues: IotFormData = props.data.value
+    const currentValues: IotFormData = props.data.value.value
       ? (props.data.value.value as IotFormData)
       : {
           pingIntervalMs: DEFAULT_PING_INTERVAL_MS,

--- a/frontend/src/pages/admin/omdb-settings.tsx
+++ b/frontend/src/pages/admin/omdb-settings.tsx
@@ -93,7 +93,7 @@ const OmdbSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
       }
     }
 
-    const currentValues: OmdbFormData = props.data.value
+    const currentValues: OmdbFormData = props.data.value.value
       ? (props.data.value.value as OmdbFormData)
       : { apiKey: '', trySearchMovieFromTitle: true, autoDownloadMetadata: true }
 

--- a/frontend/src/pages/admin/omdb-settings.tsx
+++ b/frontend/src/pages/admin/omdb-settings.tsx
@@ -10,6 +10,50 @@ type OmdbFormData = OmdbConfig['value']
 
 const OmdbSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
   shadowDomName: 'omdb-settings-content',
+  css: {
+    '& .page-description': {
+      marginBottom: '24px',
+      color: 'var(--theme-text-secondary)',
+    },
+    '& .form-field': {
+      marginBottom: '24px',
+    },
+    '& .api-key-row': {
+      display: 'flex',
+      alignItems: 'flex-end',
+      gap: '8px',
+    },
+    '& .api-key-hint': {
+      color: 'var(--theme-text-secondary)',
+      display: 'block',
+      marginTop: '4px',
+    },
+    '& .api-key-hint a': {
+      color: 'var(--theme-primary-main)',
+    },
+    '& .checkbox-label': {
+      display: 'flex',
+      alignItems: 'center',
+      gap: '12px',
+      cursor: 'pointer',
+      color: 'var(--theme-text-primary)',
+    },
+    '& .checkbox-label input': {
+      width: '18px',
+      height: '18px',
+      cursor: 'pointer',
+    },
+    '& .checkbox-title': {
+      fontWeight: '500',
+    },
+    '& .checkbox-description': {
+      color: 'var(--theme-text-secondary)',
+    },
+    '& .form-footer': {
+      borderTop: '1px solid var(--theme-background-default)',
+      paddingTop: '16px',
+    },
+  },
   render: ({ props, injector, useObservable, useDisposable, useState }) => {
     const configService = injector.getInstance(ConfigService)
     const notyService = injector.getInstance(NotyService)
@@ -139,48 +183,6 @@ export const OmdbSettingsPage = Shade({
     '& .page-title': {
       marginBottom: '24px',
       color: 'var(--theme-text-primary)',
-    },
-    '& .page-description': {
-      marginBottom: '24px',
-      color: 'var(--theme-text-secondary)',
-    },
-    '& .form-field': {
-      marginBottom: '24px',
-    },
-    '& .api-key-row': {
-      display: 'flex',
-      alignItems: 'flex-end',
-      gap: '8px',
-    },
-    '& .api-key-hint': {
-      color: 'var(--theme-text-secondary)',
-      display: 'block',
-      marginTop: '4px',
-    },
-    '& .api-key-hint a': {
-      color: 'var(--theme-primary-main)',
-    },
-    '& .checkbox-label': {
-      display: 'flex',
-      alignItems: 'center',
-      gap: '12px',
-      cursor: 'pointer',
-      color: 'var(--theme-text-primary)',
-    },
-    '& .checkbox-label input': {
-      width: '18px',
-      height: '18px',
-      cursor: 'pointer',
-    },
-    '& .checkbox-title': {
-      fontWeight: '500',
-    },
-    '& .checkbox-description': {
-      color: 'var(--theme-text-secondary)',
-    },
-    '& .form-footer': {
-      borderTop: '1px solid var(--theme-background-default)',
-      paddingTop: '16px',
     },
   },
   render: ({ injector }) => {

--- a/frontend/src/pages/admin/omdb-settings.tsx
+++ b/frontend/src/pages/admin/omdb-settings.tsx
@@ -1,75 +1,18 @@
+import type { CacheWithValue } from '@furystack/cache'
 import { createComponent, Shade } from '@furystack/shades'
-import { Button, Form, Input, NotyService, Paper } from '@furystack/shades-common-components'
+import { Button, CacheView, Form, Input, NotyService, Paper, Skeleton } from '@furystack/shades-common-components'
 import { ObservableValue } from '@furystack/utils'
-import type { OmdbConfig } from 'common'
+import type { Config, OmdbConfig } from 'common'
+import { GenericErrorPage } from '../../components/generic-error.js'
 import { ConfigService } from '../../services/config-service.js'
 
 type OmdbFormData = OmdbConfig['value']
 
-export const OmdbSettingsPage = Shade({
-  shadowDomName: 'omdb-settings-page',
-  css: {
-    '& .page-container': {
-      display: 'flex',
-      flexDirection: 'column',
-      gap: '24px',
-      height: '100%',
-    },
-    '& .page-title': {
-      marginBottom: '24px',
-      color: 'var(--theme-text-primary)',
-    },
-    '& .page-description': {
-      marginBottom: '24px',
-      color: 'var(--theme-text-secondary)',
-    },
-    '& .loading-text': {
-      color: 'var(--theme-text-secondary)',
-    },
-    '& .form-field': {
-      marginBottom: '24px',
-    },
-    '& .api-key-row': {
-      display: 'flex',
-      alignItems: 'flex-end',
-      gap: '8px',
-    },
-    '& .api-key-hint': {
-      color: 'var(--theme-text-secondary)',
-      display: 'block',
-      marginTop: '4px',
-    },
-    '& .api-key-hint a': {
-      color: 'var(--theme-primary-main)',
-    },
-    '& .checkbox-label': {
-      display: 'flex',
-      alignItems: 'center',
-      gap: '12px',
-      cursor: 'pointer',
-      color: 'var(--theme-text-primary)',
-    },
-    '& .checkbox-label input': {
-      width: '18px',
-      height: '18px',
-      cursor: 'pointer',
-    },
-    '& .checkbox-title': {
-      fontWeight: '500',
-    },
-    '& .checkbox-description': {
-      color: 'var(--theme-text-secondary)',
-    },
-    '& .form-footer': {
-      borderTop: '1px solid var(--theme-background-default)',
-      paddingTop: '16px',
-    },
-  },
-  render: ({ injector, useObservable, useDisposable, useState }) => {
+const OmdbSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
+  shadowDomName: 'omdb-settings-content',
+  render: ({ props, injector, useObservable, useDisposable, useState }) => {
     const configService = injector.getInstance(ConfigService)
     const notyService = injector.getInstance(NotyService)
-
-    const [config] = useObservable('omdbConfig', configService.getConfigAsObservable('OMDB_CONFIG'))
 
     const isLoadingObservable = useDisposable('isLoading', () => new ObservableValue(false))
     const [isLoading] = useObservable('isLoadingValue', isLoadingObservable)
@@ -106,25 +49,12 @@ export const OmdbSettingsPage = Shade({
       }
     }
 
-    if (config.status === 'loading') {
-      return (
-        <div>
-          <h2 className="page-title">🎬 OMDB Settings</h2>
-          <Paper elevation={1} style={{ padding: '24px' }}>
-            <p className="loading-text">Loading settings...</p>
-          </Paper>
-        </div>
-      )
-    }
-
-    const currentValues: OmdbFormData =
-      config.status === 'loaded' && config.value
-        ? (config.value.value as OmdbFormData)
-        : { apiKey: '', trySearchMovieFromTitle: true, autoDownloadMetadata: true }
+    const currentValues: OmdbFormData = props.data.value
+      ? (props.data.value.value as OmdbFormData)
+      : { apiKey: '', trySearchMovieFromTitle: true, autoDownloadMetadata: true }
 
     return (
-      <div className="page-container">
-        <h2 className="page-title">🎬 OMDB Settings</h2>
+      <>
         <p className="page-description">Configure the OMDB API integration for fetching movie and series metadata.</p>
 
         <Paper elevation={1} style={{ padding: '24px' }}>
@@ -192,6 +122,80 @@ export const OmdbSettingsPage = Shade({
             </div>
           </Form>
         </Paper>
+      </>
+    )
+  },
+})
+
+export const OmdbSettingsPage = Shade({
+  shadowDomName: 'omdb-settings-page',
+  css: {
+    '& .page-container': {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '24px',
+      height: '100%',
+    },
+    '& .page-title': {
+      marginBottom: '24px',
+      color: 'var(--theme-text-primary)',
+    },
+    '& .page-description': {
+      marginBottom: '24px',
+      color: 'var(--theme-text-secondary)',
+    },
+    '& .form-field': {
+      marginBottom: '24px',
+    },
+    '& .api-key-row': {
+      display: 'flex',
+      alignItems: 'flex-end',
+      gap: '8px',
+    },
+    '& .api-key-hint': {
+      color: 'var(--theme-text-secondary)',
+      display: 'block',
+      marginTop: '4px',
+    },
+    '& .api-key-hint a': {
+      color: 'var(--theme-primary-main)',
+    },
+    '& .checkbox-label': {
+      display: 'flex',
+      alignItems: 'center',
+      gap: '12px',
+      cursor: 'pointer',
+      color: 'var(--theme-text-primary)',
+    },
+    '& .checkbox-label input': {
+      width: '18px',
+      height: '18px',
+      cursor: 'pointer',
+    },
+    '& .checkbox-title': {
+      fontWeight: '500',
+    },
+    '& .checkbox-description': {
+      color: 'var(--theme-text-secondary)',
+    },
+    '& .form-footer': {
+      borderTop: '1px solid var(--theme-background-default)',
+      paddingTop: '16px',
+    },
+  },
+  render: ({ injector }) => {
+    const configService = injector.getInstance(ConfigService)
+
+    return (
+      <div className="page-container">
+        <h2 className="page-title">🎬 OMDB Settings</h2>
+        <CacheView
+          cache={configService.configCache}
+          args={['OMDB_CONFIG']}
+          content={OmdbSettingsContent}
+          loader={<Skeleton />}
+          error={(err, retry) => <GenericErrorPage error={err} retry={async () => retry()} />}
+        />
       </div>
     )
   },

--- a/frontend/src/pages/admin/streaming-settings.tsx
+++ b/frontend/src/pages/admin/streaming-settings.tsx
@@ -121,7 +121,7 @@ const StreamingSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
       }
     }
 
-    const currentValues: StreamingFormData = props.data.value
+    const currentValues: StreamingFormData = props.data.value.value
       ? (props.data.value.value as StreamingFormData)
       : {
           autoExtractSubtitles: false,

--- a/frontend/src/pages/admin/streaming-settings.tsx
+++ b/frontend/src/pages/admin/streaming-settings.tsx
@@ -22,6 +22,69 @@ const PRESET_OPTIONS = [
 
 const StreamingSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
   shadowDomName: 'streaming-settings-content',
+  css: {
+    '& .page-description': {
+      marginBottom: '24px',
+      color: 'var(--theme-text-secondary)',
+    },
+    '& .section-title': {
+      marginBottom: '16px',
+      color: 'var(--theme-text-primary)',
+      fontSize: '16px',
+    },
+    '& .form-field': {
+      marginBottom: '24px',
+    },
+    '& .checkbox-label': {
+      display: 'flex',
+      alignItems: 'center',
+      gap: '12px',
+      cursor: 'pointer',
+      color: 'var(--theme-text-primary)',
+    },
+    '& .checkbox-label input': {
+      width: '18px',
+      height: '18px',
+      cursor: 'pointer',
+    },
+    '& .checkbox-title': {
+      fontWeight: '500',
+    },
+    '& .checkbox-description': {
+      color: 'var(--theme-text-secondary)',
+    },
+    '& .section-divider': {
+      borderTop: '1px solid var(--theme-background-default)',
+      margin: '24px 0',
+      paddingTop: '24px',
+    },
+    '& .select-label': {
+      display: 'block',
+      marginBottom: '8px',
+      fontWeight: '500',
+      color: 'var(--theme-text-primary)',
+    },
+    '& .select-input': {
+      width: '100%',
+      maxWidth: '300px',
+      padding: '8px 12px',
+      fontSize: '14px',
+      borderRadius: '4px',
+      border: '1px solid var(--theme-background-paper)',
+      backgroundColor: 'var(--theme-background-default)',
+      color: 'var(--theme-text-primary)',
+      cursor: 'pointer',
+    },
+    '& .field-hint': {
+      color: 'var(--theme-text-secondary)',
+      display: 'block',
+      marginTop: '4px',
+    },
+    '& .form-footer': {
+      borderTop: '1px solid var(--theme-background-default)',
+      paddingTop: '16px',
+    },
+  },
   render: ({ props, injector, useObservable, useDisposable }) => {
     const configService = injector.getInstance(ConfigService)
     const notyService = injector.getInstance(NotyService)
@@ -175,67 +238,6 @@ export const StreamingSettingsPage = Shade({
     '& .page-title': {
       marginBottom: '24px',
       color: 'var(--theme-text-primary)',
-    },
-    '& .page-description': {
-      marginBottom: '24px',
-      color: 'var(--theme-text-secondary)',
-    },
-    '& .section-title': {
-      marginBottom: '16px',
-      color: 'var(--theme-text-primary)',
-      fontSize: '16px',
-    },
-    '& .form-field': {
-      marginBottom: '24px',
-    },
-    '& .checkbox-label': {
-      display: 'flex',
-      alignItems: 'center',
-      gap: '12px',
-      cursor: 'pointer',
-      color: 'var(--theme-text-primary)',
-    },
-    '& .checkbox-label input': {
-      width: '18px',
-      height: '18px',
-      cursor: 'pointer',
-    },
-    '& .checkbox-title': {
-      fontWeight: '500',
-    },
-    '& .checkbox-description': {
-      color: 'var(--theme-text-secondary)',
-    },
-    '& .section-divider': {
-      borderTop: '1px solid var(--theme-background-default)',
-      margin: '24px 0',
-      paddingTop: '24px',
-    },
-    '& .select-label': {
-      display: 'block',
-      marginBottom: '8px',
-      fontWeight: '500',
-      color: 'var(--theme-text-primary)',
-    },
-    '& .select-input': {
-      width: '100%',
-      maxWidth: '300px',
-      padding: '8px 12px',
-      fontSize: '14px',
-      borderRadius: '4px',
-      border: '1px solid var(--theme-background-paper)',
-      backgroundColor: 'var(--theme-background-default)',
-      color: 'var(--theme-text-primary)',
-      cursor: 'pointer',
-    },
-    '& .field-hint': {
-      color: 'var(--theme-text-secondary)',
-      display: 'block',
-      marginTop: '4px',
-    },
-    '& .form-footer': {
-      borderTop: '1px solid var(--theme-background-default)',
-      paddingTop: '16px',
     },
   },
   render: ({ injector }) => {

--- a/frontend/src/pages/admin/streaming-settings.tsx
+++ b/frontend/src/pages/admin/streaming-settings.tsx
@@ -1,7 +1,9 @@
+import type { CacheWithValue } from '@furystack/cache'
 import { createComponent, Shade } from '@furystack/shades'
-import { Button, Form, Input, NotyService, Paper } from '@furystack/shades-common-components'
+import { Button, CacheView, Form, Input, NotyService, Paper, Skeleton } from '@furystack/shades-common-components'
 import { ObservableValue } from '@furystack/utils'
-import type { MoviesConfig } from 'common'
+import type { Config, MoviesConfig } from 'common'
+import { GenericErrorPage } from '../../components/generic-error.js'
 import { ConfigService } from '../../services/config-service.js'
 
 type StreamingFormData = MoviesConfig['value']
@@ -18,83 +20,11 @@ const PRESET_OPTIONS = [
   { value: 'veryslow', label: 'Very Slow (Best Quality)' },
 ] as const
 
-export const StreamingSettingsPage = Shade({
-  shadowDomName: 'streaming-settings-page',
-  css: {
-    '& .page-title': {
-      marginBottom: '24px',
-      color: 'var(--theme-text-primary)',
-    },
-    '& .page-description': {
-      marginBottom: '24px',
-      color: 'var(--theme-text-secondary)',
-    },
-    '& .loading-text': {
-      color: 'var(--theme-text-secondary)',
-    },
-    '& .section-title': {
-      marginBottom: '16px',
-      color: 'var(--theme-text-primary)',
-      fontSize: '16px',
-    },
-    '& .form-field': {
-      marginBottom: '24px',
-    },
-    '& .checkbox-label': {
-      display: 'flex',
-      alignItems: 'center',
-      gap: '12px',
-      cursor: 'pointer',
-      color: 'var(--theme-text-primary)',
-    },
-    '& .checkbox-label input': {
-      width: '18px',
-      height: '18px',
-      cursor: 'pointer',
-    },
-    '& .checkbox-title': {
-      fontWeight: '500',
-    },
-    '& .checkbox-description': {
-      color: 'var(--theme-text-secondary)',
-    },
-    '& .section-divider': {
-      borderTop: '1px solid var(--theme-background-default)',
-      margin: '24px 0',
-      paddingTop: '24px',
-    },
-    '& .select-label': {
-      display: 'block',
-      marginBottom: '8px',
-      fontWeight: '500',
-      color: 'var(--theme-text-primary)',
-    },
-    '& .select-input': {
-      width: '100%',
-      maxWidth: '300px',
-      padding: '8px 12px',
-      fontSize: '14px',
-      borderRadius: '4px',
-      border: '1px solid var(--theme-background-paper)',
-      backgroundColor: 'var(--theme-background-default)',
-      color: 'var(--theme-text-primary)',
-      cursor: 'pointer',
-    },
-    '& .field-hint': {
-      color: 'var(--theme-text-secondary)',
-      display: 'block',
-      marginTop: '4px',
-    },
-    '& .form-footer': {
-      borderTop: '1px solid var(--theme-background-default)',
-      paddingTop: '16px',
-    },
-  },
-  render: ({ injector, useObservable, useDisposable }) => {
+const StreamingSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
+  shadowDomName: 'streaming-settings-content',
+  render: ({ props, injector, useObservable, useDisposable }) => {
     const configService = injector.getInstance(ConfigService)
     const notyService = injector.getInstance(NotyService)
-
-    const [config] = useObservable('moviesConfig', configService.getConfigAsObservable('MOVIES_CONFIG'))
 
     const isLoadingObservable = useDisposable('isLoading', () => new ObservableValue(false))
     const [isLoading] = useObservable('isLoadingValue', isLoadingObservable)
@@ -128,31 +58,18 @@ export const StreamingSettingsPage = Shade({
       }
     }
 
-    if (config.status === 'loading') {
-      return (
-        <div>
-          <h2 className="page-title">📺 Streaming Settings</h2>
-          <Paper elevation={1} style={{ padding: '24px' }}>
-            <p className="loading-text">Loading settings...</p>
-          </Paper>
-        </div>
-      )
-    }
-
-    const currentValues: StreamingFormData =
-      config.status === 'loaded' && config.value
-        ? (config.value.value as StreamingFormData)
-        : {
-            autoExtractSubtitles: false,
-            fullSyncOnStartup: false,
-            preset: 'medium',
-            threads: 4,
-            watchFiles: 'all',
-          }
+    const currentValues: StreamingFormData = props.data.value
+      ? (props.data.value.value as StreamingFormData)
+      : {
+          autoExtractSubtitles: false,
+          fullSyncOnStartup: false,
+          preset: 'medium',
+          threads: 4,
+          watchFiles: 'all',
+        }
 
     return (
-      <div>
-        <h2 className="page-title">📺 Streaming Settings</h2>
+      <>
         <p className="page-description">Configure media transcoding and file watching settings.</p>
 
         <Paper elevation={1} style={{ padding: '24px' }}>
@@ -247,6 +164,93 @@ export const StreamingSettingsPage = Shade({
             </div>
           </Form>
         </Paper>
+      </>
+    )
+  },
+})
+
+export const StreamingSettingsPage = Shade({
+  shadowDomName: 'streaming-settings-page',
+  css: {
+    '& .page-title': {
+      marginBottom: '24px',
+      color: 'var(--theme-text-primary)',
+    },
+    '& .page-description': {
+      marginBottom: '24px',
+      color: 'var(--theme-text-secondary)',
+    },
+    '& .section-title': {
+      marginBottom: '16px',
+      color: 'var(--theme-text-primary)',
+      fontSize: '16px',
+    },
+    '& .form-field': {
+      marginBottom: '24px',
+    },
+    '& .checkbox-label': {
+      display: 'flex',
+      alignItems: 'center',
+      gap: '12px',
+      cursor: 'pointer',
+      color: 'var(--theme-text-primary)',
+    },
+    '& .checkbox-label input': {
+      width: '18px',
+      height: '18px',
+      cursor: 'pointer',
+    },
+    '& .checkbox-title': {
+      fontWeight: '500',
+    },
+    '& .checkbox-description': {
+      color: 'var(--theme-text-secondary)',
+    },
+    '& .section-divider': {
+      borderTop: '1px solid var(--theme-background-default)',
+      margin: '24px 0',
+      paddingTop: '24px',
+    },
+    '& .select-label': {
+      display: 'block',
+      marginBottom: '8px',
+      fontWeight: '500',
+      color: 'var(--theme-text-primary)',
+    },
+    '& .select-input': {
+      width: '100%',
+      maxWidth: '300px',
+      padding: '8px 12px',
+      fontSize: '14px',
+      borderRadius: '4px',
+      border: '1px solid var(--theme-background-paper)',
+      backgroundColor: 'var(--theme-background-default)',
+      color: 'var(--theme-text-primary)',
+      cursor: 'pointer',
+    },
+    '& .field-hint': {
+      color: 'var(--theme-text-secondary)',
+      display: 'block',
+      marginTop: '4px',
+    },
+    '& .form-footer': {
+      borderTop: '1px solid var(--theme-background-default)',
+      paddingTop: '16px',
+    },
+  },
+  render: ({ injector }) => {
+    const configService = injector.getInstance(ConfigService)
+
+    return (
+      <div>
+        <h2 className="page-title">📺 Streaming Settings</h2>
+        <CacheView
+          cache={configService.configCache}
+          args={['MOVIES_CONFIG']}
+          content={StreamingSettingsContent}
+          loader={<Skeleton />}
+          error={(err, retry) => <GenericErrorPage error={err} retry={async () => retry()} />}
+        />
       </div>
     )
   },

--- a/frontend/src/pages/admin/user-details.spec.tsx
+++ b/frontend/src/pages/admin/user-details.spec.tsx
@@ -1,11 +1,11 @@
+import { Cache } from '@furystack/cache'
 import { Injector } from '@furystack/inject'
 import { LocationService, createComponent, flushUpdates, initializeShadeRoot } from '@furystack/shades'
 import { NotyService } from '@furystack/shades-common-components'
-import { ObservableValue } from '@furystack/utils'
 import type { User } from 'common'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { UsersService } from '../../services/users-service.js'
-import { type CacheState, createMockUser } from '../../test-utils/user-test-helpers.js'
+import { createMockUser } from '../../test-utils/user-test-helpers.js'
 import { UserDetailsPage } from './user-details.js'
 
 /**
@@ -13,32 +13,41 @@ import { UserDetailsPage } from './user-details.js'
  */
 const getActionButtons = (page: Element | null | undefined) => {
   const allButtons = Array.from(page?.querySelectorAll('button') ?? [])
-  // Filter out buttons that are inside role-tag elements
   return allButtons.filter((btn) => !btn.closest('role-tag'))
 }
 
 describe('UserDetailsPage', () => {
   let injector: Injector
   let mockUsersService: {
-    getUserAsObservable: ReturnType<typeof vi.fn>
+    userCache: Cache<User, [string]>
     updateUser: ReturnType<typeof vi.fn>
   }
   let mockNotyService: {
     emit: ReturnType<typeof vi.fn>
   }
-  let userObservable: ObservableValue<CacheState<User>>
+
+  const seedUserCache = (username: string, roles: User['roles']) => {
+    mockUsersService.userCache.setExplicitValue({
+      loadArgs: [username],
+      value: { status: 'loaded', value: createMockUser(username, roles), updatedAt: new Date() },
+    })
+  }
 
   beforeEach(() => {
     document.body.innerHTML = '<div id="root"></div>'
 
-    userObservable = new ObservableValue<CacheState<User>>({
-      status: 'loaded',
-      value: createMockUser('testuser@example.com', ['admin']),
-      updatedAt: new Date(),
+    const userCache = new Cache<User, [string]>({
+      capacity: 10,
+      load: vi.fn().mockResolvedValue(createMockUser('testuser@example.com', ['admin'])),
+    })
+
+    userCache.setExplicitValue({
+      loadArgs: ['testuser@example.com'],
+      value: { status: 'loaded', value: createMockUser('testuser@example.com', ['admin']), updatedAt: new Date() },
     })
 
     mockUsersService = {
-      getUserAsObservable: vi.fn().mockReturnValue(userObservable),
+      userCache,
       updateUser: vi.fn().mockResolvedValue(createMockUser('testuser@example.com', ['admin', 'viewer'])),
     }
 
@@ -72,8 +81,14 @@ describe('UserDetailsPage', () => {
       expect(page?.textContent).toContain('User Details')
     })
 
-    it('should display loading state', async () => {
-      userObservable.setValue({ status: 'loading' })
+    it('should display loader when loading', async () => {
+      const neverResolvingCache = new Cache<User, [string]>({
+        capacity: 10,
+        load: () => new Promise(() => {}),
+      })
+      mockUsersService.userCache = neverResolvingCache
+
+      injector.setExplicitInstance(mockUsersService as unknown as UsersService, UsersService)
 
       const rootElement = document.getElementById('root') as HTMLDivElement
 
@@ -85,14 +100,14 @@ describe('UserDetailsPage', () => {
       await flushUpdates()
 
       const page = document.querySelector('user-details-page')
-      expect(page?.textContent).toContain('Loading user...')
+      const skeleton = page?.querySelector('shade-skeleton')
+      expect(skeleton).toBeTruthy()
     })
 
-    it('should display error state with go back button', async () => {
-      userObservable.setValue({
-        status: 'failed',
-        error: new Error('User not found'),
-        updatedAt: new Date(),
+    it('should display error state', async () => {
+      mockUsersService.userCache.setExplicitValue({
+        loadArgs: ['nonexistent@example.com'],
+        value: { status: 'failed', error: new Error('User not found'), updatedAt: new Date() },
       })
 
       const rootElement = document.getElementById('root') as HTMLDivElement
@@ -103,33 +118,10 @@ describe('UserDetailsPage', () => {
         jsxElement: <UserDetailsPage username="nonexistent@example.com" />,
       })
       await flushUpdates()
-
-      const page = document.querySelector('user-details-page')
-      expect(page?.textContent).toContain('Error: User not found')
-      // Go Back button exists - Button component renders as button element
-      const buttons = page?.querySelectorAll('button')
-      // Should have Back button and Go Back button
-      expect(buttons?.length).toBeGreaterThanOrEqual(1)
-    })
-
-    it('should display fallback error message for non-Error objects', async () => {
-      userObservable.setValue({
-        status: 'failed',
-        error: 'string error',
-        updatedAt: new Date(),
-      })
-
-      const rootElement = document.getElementById('root') as HTMLDivElement
-
-      initializeShadeRoot({
-        injector,
-        rootElement,
-        jsxElement: <UserDetailsPage username="testuser@example.com" />,
-      })
       await flushUpdates()
 
       const page = document.querySelector('user-details-page')
-      expect(page?.textContent).toContain('Failed to load user')
+      expect(page?.textContent).toContain('User not found')
     })
   })
 
@@ -210,11 +202,7 @@ describe('UserDetailsPage', () => {
     })
 
     it('should render multiple role tags for user with multiple roles', async () => {
-      userObservable.setValue({
-        status: 'loaded',
-        value: createMockUser('testuser@example.com', ['admin', 'viewer', 'media-manager']),
-        updatedAt: new Date(),
-      })
+      seedUserCache('testuser@example.com', ['admin', 'viewer', 'media-manager'])
 
       const rootElement = document.getElementById('root') as HTMLDivElement
 
@@ -232,11 +220,7 @@ describe('UserDetailsPage', () => {
     })
 
     it('should display "No roles assigned" for user without roles', async () => {
-      userObservable.setValue({
-        status: 'loaded',
-        value: createMockUser('testuser@example.com', []),
-        updatedAt: new Date(),
-      })
+      seedUserCache('testuser@example.com', [])
 
       const rootElement = document.getElementById('root') as HTMLDivElement
 
@@ -271,11 +255,7 @@ describe('UserDetailsPage', () => {
     })
 
     it('should show available roles that user does not have', async () => {
-      userObservable.setValue({
-        status: 'loaded',
-        value: createMockUser('testuser@example.com', ['admin']),
-        updatedAt: new Date(),
-      })
+      seedUserCache('testuser@example.com', ['admin'])
 
       const rootElement = document.getElementById('root') as HTMLDivElement
 
@@ -300,11 +280,7 @@ describe('UserDetailsPage', () => {
     })
 
     it('should not show dropdown when user has all roles', async () => {
-      userObservable.setValue({
-        status: 'loaded',
-        value: createMockUser('testuser@example.com', ['admin', 'viewer', 'media-manager', 'iot-manager']),
-        updatedAt: new Date(),
-      })
+      seedUserCache('testuser@example.com', ['admin', 'viewer', 'media-manager', 'iot-manager'])
 
       const rootElement = document.getElementById('root') as HTMLDivElement
 
@@ -349,9 +325,7 @@ describe('UserDetailsPage', () => {
       await flushUpdates()
 
       const page = document.querySelector('user-details-page')
-      // Button component sets disabled attribute on the button element
       const disabledButtons = page?.querySelectorAll('button[disabled]')
-      // Save and Cancel buttons should be disabled (Back is always enabled)
       expect(disabledButtons?.length).toBe(2)
     })
   })
@@ -370,7 +344,6 @@ describe('UserDetailsPage', () => {
       await flushUpdates()
 
       const page = document.querySelector('user-details-page')
-      // Back button is the first button element in the page
       const backButton = page?.querySelector('button') as HTMLButtonElement
 
       backButton.click()
@@ -394,26 +367,19 @@ describe('UserDetailsPage', () => {
       const page = document.querySelector('user-details-page')
       const select = page?.querySelector('select') as HTMLSelectElement
 
-      // Simulate selecting a role
       select.value = 'viewer'
       select.dispatchEvent(new Event('change', { bubbles: true }))
       await flushUpdates()
 
-      // Should now have 2 role tags (admin + viewer)
       const roleTags = page?.querySelectorAll('role-tag')
       expect(roleTags?.length).toBe(2)
 
-      // No disabled buttons anymore (Save and Cancel are enabled)
       const disabledButtons = page?.querySelectorAll('button[disabled]')
       expect(disabledButtons?.length).toBe(0)
     })
 
     it('should remove role when remove button is clicked', async () => {
-      userObservable.setValue({
-        status: 'loaded',
-        value: createMockUser('testuser@example.com', ['admin', 'viewer']),
-        updatedAt: new Date(),
-      })
+      seedUserCache('testuser@example.com', ['admin', 'viewer'])
 
       const rootElement = document.getElementById('root') as HTMLDivElement
 
@@ -427,17 +393,14 @@ describe('UserDetailsPage', () => {
 
       const page = document.querySelector('user-details-page')
 
-      // Find and click the remove button on a role tag
       const roleTag = page?.querySelector('role-tag')
       const removeButton = roleTag?.querySelector('button')
       removeButton?.click()
 
-      // Wait for re-render
       await new Promise((resolve) => setTimeout(resolve, 10))
       await flushUpdates()
       await flushUpdates()
 
-      // No disabled buttons (Save and Cancel are enabled)
       const disabledButtons = page?.querySelectorAll('button[disabled]')
       expect(disabledButtons?.length).toBe(0)
     })
@@ -455,28 +418,21 @@ describe('UserDetailsPage', () => {
       const page = document.querySelector('user-details-page')
       const select = page?.querySelector('select') as HTMLSelectElement
 
-      // Add a role
       select.value = 'viewer'
       select.dispatchEvent(new Event('change', { bubbles: true }))
 
-      // Wait for state update
       await new Promise((resolve) => setTimeout(resolve, 10))
 
-      // Get action buttons (excluding role-tag buttons): Back (0), Save (1), Cancel (2)
       const allButtons = Array.from(page?.querySelectorAll('button') ?? [])
       const actionButtons = allButtons.filter((btn) => !btn.closest('role-tag'))
-      // Cancel is the last action button
       const cancelButton = actionButtons[actionButtons.length - 1]
       cancelButton.click()
 
-      // Wait for re-render
       await new Promise((resolve) => setTimeout(resolve, 10))
 
-      // Should be back to original state (1 role tag)
       const roleTags = page?.querySelectorAll('role-tag')
       expect(roleTags?.length).toBe(1)
 
-      // Save and Cancel buttons should be disabled again
       const disabledButtons = page?.querySelectorAll('button[disabled]')
       expect(disabledButtons?.length).toBe(2)
     })
@@ -496,19 +452,15 @@ describe('UserDetailsPage', () => {
       const page = document.querySelector('user-details-page')
       const select = page?.querySelector('select') as HTMLSelectElement
 
-      // Add a role
       select.value = 'viewer'
       select.dispatchEvent(new Event('change', { bubbles: true }))
 
-      // Wait for state update
       await new Promise((resolve) => setTimeout(resolve, 10))
 
-      // Get action buttons (excluding role-tag buttons): Back (0), Save (1), Cancel (2)
       const actionButtons = getActionButtons(page)
       const saveButton = actionButtons[1]
       saveButton.click()
 
-      // Wait for async save
       await new Promise((resolve) => setTimeout(resolve, 50))
 
       expect(mockUsersService.updateUser).toHaveBeenCalledWith('testuser@example.com', {
@@ -530,13 +482,11 @@ describe('UserDetailsPage', () => {
       const page = document.querySelector('user-details-page')
       const select = page?.querySelector('select') as HTMLSelectElement
 
-      // Add a role
       select.value = 'viewer'
       select.dispatchEvent(new Event('change', { bubbles: true }))
 
       await new Promise((resolve) => setTimeout(resolve, 10))
 
-      // Click Save
       const actionButtons = getActionButtons(page)
       const saveButton = actionButtons[1]
       saveButton.click()
@@ -565,13 +515,11 @@ describe('UserDetailsPage', () => {
       const page = document.querySelector('user-details-page')
       const select = page?.querySelector('select') as HTMLSelectElement
 
-      // Add a role
       select.value = 'viewer'
       select.dispatchEvent(new Event('change', { bubbles: true }))
 
       await new Promise((resolve) => setTimeout(resolve, 10))
 
-      // Click Save
       const actionButtons = getActionButtons(page)
       const saveButton = actionButtons[1]
       saveButton.click()
@@ -586,7 +534,6 @@ describe('UserDetailsPage', () => {
     })
 
     it('should disable buttons while saving', async () => {
-      // Make updateUser slow - need to delay to check the saving state
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       mockUsersService.updateUser.mockImplementation(() => {
         return new Promise<User>((resolve) => {
@@ -608,37 +555,28 @@ describe('UserDetailsPage', () => {
       const page = document.querySelector('user-details-page')
       const select = page?.querySelector('select') as HTMLSelectElement
 
-      // Add a role
       select.value = 'viewer'
       select.dispatchEvent(new Event('change', { bubbles: true }))
 
       await new Promise((resolve) => setTimeout(resolve, 10))
 
-      // Verify buttons are enabled before save
       const actionButtonsBefore = getActionButtons(page)
-      expect(actionButtonsBefore[1]?.disabled).toBe(false) // Save
-      expect(actionButtonsBefore[2]?.disabled).toBe(false) // Cancel
+      expect(actionButtonsBefore[1]?.disabled).toBe(false)
+      expect(actionButtonsBefore[2]?.disabled).toBe(false)
 
-      // Click Save
       actionButtonsBefore[1]?.click()
 
-      // Wait a bit for state to update
       await new Promise((resolve) => setTimeout(resolve, 10))
 
-      // Both Save and Cancel should be disabled while saving
       const actionButtonsAfter = getActionButtons(page)
-      expect(actionButtonsAfter[1]?.disabled).toBe(true) // Save
-      expect(actionButtonsAfter[2]?.disabled).toBe(true) // Cancel
+      expect(actionButtonsAfter[1]?.disabled).toBe(true)
+      expect(actionButtonsAfter[2]?.disabled).toBe(true)
     })
   })
 
   describe('validation', () => {
     it('should show validation error when trying to save with no roles', async () => {
-      userObservable.setValue({
-        status: 'loaded',
-        value: createMockUser('testuser@example.com', ['viewer']),
-        updatedAt: new Date(),
-      })
+      seedUserCache('testuser@example.com', ['viewer'])
 
       const rootElement = document.getElementById('root') as HTMLDivElement
 
@@ -652,7 +590,6 @@ describe('UserDetailsPage', () => {
 
       const page = document.querySelector('user-details-page')
 
-      // Remove the only role
       const roleTag = page?.querySelector('role-tag')
       const removeButton = roleTag?.querySelector('button')
       removeButton?.click()
@@ -661,7 +598,6 @@ describe('UserDetailsPage', () => {
       await flushUpdates()
       await flushUpdates()
 
-      // Click Save (index 1 of action buttons, excluding role-tag buttons)
       const actionButtons = getActionButtons(page)
       const saveButton = actionButtons[1]
       saveButton.click()
@@ -672,21 +608,6 @@ describe('UserDetailsPage', () => {
 
       expect(page?.textContent).toContain('User must have at least one role')
       expect(mockUsersService.updateUser).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('service integration', () => {
-    it('should call getUserAsObservable with username on render', async () => {
-      const rootElement = document.getElementById('root') as HTMLDivElement
-
-      initializeShadeRoot({
-        injector,
-        rootElement,
-        jsxElement: <UserDetailsPage username="testuser@example.com" />,
-      })
-      await flushUpdates()
-
-      expect(mockUsersService.getUserAsObservable).toHaveBeenCalledWith('testuser@example.com')
     })
   })
 })

--- a/frontend/src/pages/admin/user-details.tsx
+++ b/frontend/src/pages/admin/user-details.tsx
@@ -1,20 +1,254 @@
-import { hasCacheValue, isFailedCacheResult } from '@furystack/cache'
+import type { CacheWithValue } from '@furystack/cache'
 import { createComponent, Shade } from '@furystack/shades'
-import { Button, NotyService, Paper } from '@furystack/shades-common-components'
+import { Button, CacheView, NotyService, Paper, Skeleton } from '@furystack/shades-common-components'
 import { ObservableValue } from '@furystack/utils'
-import type { Roles } from 'common'
+import type { Roles, User } from 'common'
 import { getAllRoleDefinitions } from 'common'
 import { navigateToRoute } from '../../navigate-to-route.js'
 import { RoleTag } from '../../components/role-tag/index.js'
+import { GenericErrorPage } from '../../components/generic-error.js'
 import { UsersService } from '../../services/users-service.js'
-
-type UserDetailsPageProps = {
-  username: string
-}
 
 type RoleChange = {
   originalRoles: Roles
   currentRoles: Roles
+}
+
+const UserDetailsContent = Shade<{ data: CacheWithValue<User> }>({
+  shadowDomName: 'user-details-content',
+  render: ({ props, injector, useObservable, useDisposable }) => {
+    const usersService = injector.getInstance(UsersService)
+    const notyService = injector.getInstance(NotyService)
+    const user = props.data.value
+
+    const roleChangeObservable = useDisposable('roleChange', () => new ObservableValue<RoleChange | null>(null))
+    const [roleChange] = useObservable('roleChangeValue', roleChangeObservable)
+
+    const isSavingObservable = useDisposable('isSaving', () => new ObservableValue(false))
+    const [isSaving] = useObservable('isSavingValue', isSavingObservable)
+
+    const validationErrorObservable = useDisposable('validationError', () => new ObservableValue<string | null>(null))
+    const [validationError] = useObservable('validationErrorValue', validationErrorObservable)
+
+    const isRoleStateInitialized = useDisposable('isRoleStateInitialized', () => new ObservableValue(false))
+
+    if (!isRoleStateInitialized.getValue()) {
+      isRoleStateInitialized.setValue(true)
+      roleChangeObservable.setValue({
+        originalRoles: [...user.roles],
+        currentRoles: [...user.roles],
+      })
+    }
+
+    const formatDate = (dateString: string) => {
+      return new Date(dateString).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    }
+
+    const addRole = (roleName: Roles[number]) => {
+      const current = roleChange?.currentRoles ?? user.roles
+      const original = roleChange?.originalRoles ?? user.roles
+      if (current.includes(roleName)) return
+      roleChangeObservable.setValue({
+        originalRoles: [...original],
+        currentRoles: [...current, roleName],
+      })
+      validationErrorObservable.setValue(null)
+    }
+
+    const removeRole = (roleName: Roles[number]) => {
+      const current = roleChange?.currentRoles ?? user.roles
+      const original = roleChange?.originalRoles ?? user.roles
+      roleChangeObservable.setValue({
+        originalRoles: [...original],
+        currentRoles: current.filter((r) => r !== roleName),
+      })
+    }
+
+    const restoreRole = (roleName: Roles[number]) => {
+      const current = roleChange?.currentRoles ?? user.roles
+      const original = roleChange?.originalRoles ?? user.roles
+      if (current.includes(roleName)) return
+      roleChangeObservable.setValue({
+        originalRoles: [...original],
+        currentRoles: [...current, roleName],
+      })
+      validationErrorObservable.setValue(null)
+    }
+
+    const getRoleVariant = (roleName: Roles[number]): 'default' | 'added' | 'removed' => {
+      const original = roleChange?.originalRoles ?? user.roles
+      const current = roleChange?.currentRoles ?? user.roles
+      const isInOriginal = original.includes(roleName)
+      const isInCurrent = current.includes(roleName)
+
+      if (isInOriginal && isInCurrent) return 'default'
+      if (!isInOriginal && isInCurrent) return 'added'
+      if (isInOriginal && !isInCurrent) return 'removed'
+      return 'default'
+    }
+
+    const hasChanges = () => {
+      const original = roleChange?.originalRoles ?? user.roles
+      const current = roleChange?.currentRoles ?? user.roles
+      const originalSorted = [...original].sort()
+      const currentSorted = [...current].sort()
+      if (originalSorted.length !== currentSorted.length) return true
+      return originalSorted.some((role, idx) => role !== currentSorted[idx])
+    }
+
+    const handleSave = async () => {
+      const current = roleChange?.currentRoles ?? user.roles
+
+      if (current.length === 0) {
+        validationErrorObservable.setValue('User must have at least one role')
+        return
+      }
+
+      isSavingObservable.setValue(true)
+      validationErrorObservable.setValue(null)
+
+      try {
+        await usersService.updateUser(user.username, {
+          username: user.username,
+          roles: current,
+        })
+
+        notyService.emit('onNotyAdded', {
+          title: 'Success',
+          body: 'User roles updated successfully',
+          type: 'success',
+        })
+
+        if (!roleChangeObservable.isDisposed) {
+          roleChangeObservable.setValue({
+            originalRoles: [...current],
+            currentRoles: [...current],
+          })
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Failed to save user'
+        notyService.emit('onNotyAdded', {
+          title: 'Error',
+          body: errorMessage,
+          type: 'error',
+        })
+      } finally {
+        if (!isSavingObservable.isDisposed) {
+          isSavingObservable.setValue(false)
+        }
+      }
+    }
+
+    const handleCancel = () => {
+      if (roleChange) {
+        roleChangeObservable.setValue({
+          ...roleChange,
+          currentRoles: [...roleChange.originalRoles],
+        })
+        validationErrorObservable.setValue(null)
+      }
+    }
+
+    const allRoles = getAllRoleDefinitions()
+
+    const currentRoles = roleChange?.currentRoles ?? user.roles
+    const originalRoles = roleChange?.originalRoles ?? user.roles
+
+    const availableRolesToAdd = allRoles.filter((role) => !currentRoles.includes(role.name))
+
+    const rolesToDisplay = [...new Set([...originalRoles, ...currentRoles])]
+
+    return (
+      <>
+        <Paper elevation={1} style={{ padding: '24px' }}>
+          <h3 className="section-title">User Information</h3>
+
+          <div className="info-grid">
+            <span className="info-label">Username:</span>
+            <span className="info-value">{user.username}</span>
+
+            <span className="info-label">Created:</span>
+            <span className="info-value">{formatDate(user.createdAt)}</span>
+
+            <span className="info-label">Last Updated:</span>
+            <span className="info-value">{formatDate(user.updatedAt)}</span>
+          </div>
+        </Paper>
+
+        <Paper elevation={1} style={{ padding: '24px' }}>
+          <h3 className="section-title">Roles</h3>
+
+          <div className="roles-container">
+            <div className="roles-list">
+              {rolesToDisplay.length > 0 ? (
+                rolesToDisplay.map((roleName) => {
+                  const variant = getRoleVariant(roleName)
+                  return (
+                    <RoleTag
+                      roleName={roleName}
+                      variant={variant}
+                      onRemove={variant !== 'removed' ? () => removeRole(roleName) : undefined}
+                      onRestore={variant === 'removed' ? () => restoreRole(roleName) : undefined}
+                    />
+                  )
+                })
+              ) : (
+                <span className="no-roles">No roles assigned</span>
+              )}
+            </div>
+          </div>
+
+          {availableRolesToAdd.length > 0 && (
+            <div className="add-role-container">
+              <label className="add-role-label">Add Role:</label>
+              <select
+                className="add-role-select"
+                onchange={(e) => {
+                  const select = e.target as HTMLSelectElement
+                  const roleName = select.value as Roles[number]
+                  if (roleName) {
+                    addRole(roleName)
+                    select.value = ''
+                  }
+                }}
+              >
+                <option value="">Select a role to add...</option>
+                {availableRolesToAdd.map((role) => (
+                  <option value={role.name}>{role.displayName}</option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {validationError && <div className="validation-error">{validationError}</div>}
+
+          <div className="button-row">
+            <Button
+              variant="contained"
+              color="primary"
+              onclick={() => void handleSave()}
+              disabled={isSaving || !hasChanges()}
+            >
+              {isSaving ? 'Saving...' : 'Save Changes'}
+            </Button>
+            <Button variant="outlined" onclick={handleCancel} disabled={isSaving || !hasChanges()}>
+              Cancel
+            </Button>
+          </div>
+        </Paper>
+      </>
+    )
+  },
+})
+
+type UserDetailsPageProps = {
+  username: string
 }
 
 export const UserDetailsPage = Shade<UserDetailsPageProps>({
@@ -34,12 +268,6 @@ export const UserDetailsPage = Shade<UserDetailsPageProps>({
     '& .page-header h2': {
       margin: '0',
       color: 'var(--theme-text-primary)',
-    },
-    '& .loading-text': {
-      color: 'var(--theme-text-secondary)',
-    },
-    '& .error-text': {
-      color: 'var(--theme-error-main)',
     },
     '& .section-title': {
       marginTop: '0',
@@ -107,184 +335,12 @@ export const UserDetailsPage = Shade<UserDetailsPageProps>({
       paddingTop: '16px',
     },
   },
-  render: ({ props, injector, useObservable, useDisposable }) => {
+  render: ({ props, injector }) => {
     const usersService = injector.getInstance(UsersService)
-    const notyService = injector.getInstance(NotyService)
-
-    const { username } = props
-
-    const [userState] = useObservable('user', usersService.getUserAsObservable(username))
-
-    const roleChangeObservable = useDisposable('roleChange', () => new ObservableValue<RoleChange | null>(null))
-    const [roleChange] = useObservable('roleChangeValue', roleChangeObservable)
-
-    const isSavingObservable = useDisposable('isSaving', () => new ObservableValue(false))
-    const [isSaving] = useObservable('isSavingValue', isSavingObservable)
-
-    const validationErrorObservable = useDisposable('validationError', () => new ObservableValue<string | null>(null))
-    const [validationError] = useObservable('validationErrorValue', validationErrorObservable)
-
-    // Track if role state has been initialized to prevent re-initialization during render cycles
-    const isRoleStateInitialized = useDisposable('isRoleStateInitialized', () => new ObservableValue(false))
-
-    // Initialize role change state when user is loaded (check synchronously to avoid race conditions)
-    if (userState.status === 'loaded' && !isRoleStateInitialized.getValue()) {
-      isRoleStateInitialized.setValue(true)
-      roleChangeObservable.setValue({
-        originalRoles: [...userState.value.roles],
-        currentRoles: [...userState.value.roles],
-      })
-    }
 
     const navigateBack = () => {
       navigateToRoute(injector, '/app-settings/users')
     }
-
-    const formatDate = (dateString: string) => {
-      return new Date(dateString).toLocaleDateString(undefined, {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-      })
-    }
-
-    const getErrorMessage = (error: unknown): string => {
-      if (error instanceof Error) return error.message
-      return 'Failed to load user'
-    }
-
-    const addRole = (roleName: Roles[number]) => {
-      if (userState.status !== 'loaded') return
-      const current = roleChange?.currentRoles ?? userState.value.roles
-      const original = roleChange?.originalRoles ?? userState.value.roles
-      if (current.includes(roleName)) return
-      roleChangeObservable.setValue({
-        originalRoles: [...original],
-        currentRoles: [...current, roleName],
-      })
-      validationErrorObservable.setValue(null)
-    }
-
-    const removeRole = (roleName: Roles[number]) => {
-      if (userState.status !== 'loaded') return
-      const current = roleChange?.currentRoles ?? userState.value.roles
-      const original = roleChange?.originalRoles ?? userState.value.roles
-      roleChangeObservable.setValue({
-        originalRoles: [...original],
-        currentRoles: current.filter((r) => r !== roleName),
-      })
-    }
-
-    const restoreRole = (roleName: Roles[number]) => {
-      if (userState.status !== 'loaded') return
-      const current = roleChange?.currentRoles ?? userState.value.roles
-      const original = roleChange?.originalRoles ?? userState.value.roles
-      if (current.includes(roleName)) return
-      roleChangeObservable.setValue({
-        originalRoles: [...original],
-        currentRoles: [...current, roleName],
-      })
-      validationErrorObservable.setValue(null)
-    }
-
-    const getRoleVariant = (roleName: Roles[number]): 'default' | 'added' | 'removed' => {
-      if (userState.status !== 'loaded') return 'default'
-      const original = roleChange?.originalRoles ?? userState.value.roles
-      const current = roleChange?.currentRoles ?? userState.value.roles
-      const isInOriginal = original.includes(roleName)
-      const isInCurrent = current.includes(roleName)
-
-      if (isInOriginal && isInCurrent) return 'default'
-      if (!isInOriginal && isInCurrent) return 'added'
-      if (isInOriginal && !isInCurrent) return 'removed'
-      return 'default'
-    }
-
-    const hasChanges = () => {
-      if (userState.status !== 'loaded') return false
-      const original = roleChange?.originalRoles ?? userState.value.roles
-      const current = roleChange?.currentRoles ?? userState.value.roles
-      const originalSorted = [...original].sort()
-      const currentSorted = [...current].sort()
-      if (originalSorted.length !== currentSorted.length) return true
-      return originalSorted.some((role, idx) => role !== currentSorted[idx])
-    }
-
-    const handleSave = async () => {
-      if (userState.status !== 'loaded') return
-
-      const current = roleChange?.currentRoles ?? userState.value.roles
-
-      // Validation
-      if (current.length === 0) {
-        validationErrorObservable.setValue('User must have at least one role')
-        return
-      }
-
-      isSavingObservable.setValue(true)
-      validationErrorObservable.setValue(null)
-
-      try {
-        await usersService.updateUser(username, {
-          username: userState.value.username,
-          roles: current,
-        })
-
-        notyService.emit('onNotyAdded', {
-          title: 'Success',
-          body: 'User roles updated successfully',
-          type: 'success',
-        })
-
-        // Update the original roles to reflect saved state (guard against disposal during async operation)
-        if (!roleChangeObservable.isDisposed) {
-          roleChangeObservable.setValue({
-            originalRoles: [...current],
-            currentRoles: [...current],
-          })
-        }
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : 'Failed to save user'
-        notyService.emit('onNotyAdded', {
-          title: 'Error',
-          body: errorMessage,
-          type: 'error',
-        })
-      } finally {
-        // Guard against disposal during async operation (component may have unmounted)
-        if (!isSavingObservable.isDisposed) {
-          isSavingObservable.setValue(false)
-        }
-      }
-    }
-
-    const handleCancel = () => {
-      if (roleChange) {
-        roleChangeObservable.setValue({
-          ...roleChange,
-          currentRoles: [...roleChange.originalRoles],
-        })
-        validationErrorObservable.setValue(null)
-      }
-    }
-
-    const allRoles = getAllRoleDefinitions()
-
-    // Get current roles from roleChange if available, otherwise from userState
-    const currentRoles = roleChange?.currentRoles ?? (userState.status === 'loaded' ? userState.value.roles : [])
-    const originalRoles = roleChange?.originalRoles ?? (userState.status === 'loaded' ? userState.value.roles : [])
-
-    const availableRolesToAdd = allRoles.filter((role) => !currentRoles.includes(role.name))
-
-    // Get all roles to display (current + removed)
-    const rolesToDisplay = [
-      ...new Set([
-        ...originalRoles, // Include original roles (may be removed)
-        ...currentRoles, // Include current roles (may be added)
-      ]),
-    ]
 
     return (
       <div className="page-container">
@@ -294,102 +350,13 @@ export const UserDetailsPage = Shade<UserDetailsPageProps>({
           </Button>
           <h2>User Details</h2>
         </div>
-
-        {(userState.status === 'loading' || userState.status === 'obsolete') && (
-          <Paper elevation={1} style={{ padding: '24px' }}>
-            <p className="loading-text">Loading user...</p>
-          </Paper>
-        )}
-
-        {isFailedCacheResult(userState) && (
-          <Paper elevation={1} style={{ padding: '24px' }}>
-            <p className="error-text">Error: {getErrorMessage(userState.error)}</p>
-            <Button variant="outlined" onclick={navigateBack} style={{ marginTop: '12px' }}>
-              Go Back
-            </Button>
-          </Paper>
-        )}
-
-        {hasCacheValue(userState) && (
-          <>
-            <Paper elevation={1} style={{ padding: '24px' }}>
-              <h3 className="section-title">User Information</h3>
-
-              <div className="info-grid">
-                <span className="info-label">Username:</span>
-                <span className="info-value">{userState.value.username}</span>
-
-                <span className="info-label">Created:</span>
-                <span className="info-value">{formatDate(userState.value.createdAt)}</span>
-
-                <span className="info-label">Last Updated:</span>
-                <span className="info-value">{formatDate(userState.value.updatedAt)}</span>
-              </div>
-            </Paper>
-
-            <Paper elevation={1} style={{ padding: '24px' }}>
-              <h3 className="section-title">Roles</h3>
-
-              <div className="roles-container">
-                <div className="roles-list">
-                  {rolesToDisplay.length > 0 ? (
-                    rolesToDisplay.map((roleName) => {
-                      const variant = getRoleVariant(roleName)
-                      return (
-                        <RoleTag
-                          roleName={roleName}
-                          variant={variant}
-                          onRemove={variant !== 'removed' ? () => removeRole(roleName) : undefined}
-                          onRestore={variant === 'removed' ? () => restoreRole(roleName) : undefined}
-                        />
-                      )
-                    })
-                  ) : (
-                    <span className="no-roles">No roles assigned</span>
-                  )}
-                </div>
-              </div>
-
-              {availableRolesToAdd.length > 0 && (
-                <div className="add-role-container">
-                  <label className="add-role-label">Add Role:</label>
-                  <select
-                    className="add-role-select"
-                    onchange={(e) => {
-                      const select = e.target as HTMLSelectElement
-                      const roleName = select.value as Roles[number]
-                      if (roleName) {
-                        addRole(roleName)
-                        select.value = ''
-                      }
-                    }}
-                  >
-                    <option value="">Select a role to add...</option>
-                    {availableRolesToAdd.map((role) => (
-                      <option value={role.name}>{role.displayName}</option>
-                    ))}
-                  </select>
-                </div>
-              )}
-
-              {validationError && <div className="validation-error">{validationError}</div>}
-
-              <div className="button-row">
-                <Button
-                  variant="contained"
-                  color="primary"
-                  onclick={() => void handleSave()}
-                  disabled={isSaving || !hasChanges()}
-                >
-                  {isSaving ? 'Saving...' : 'Save Changes'}
-                </Button>
-                <Button variant="outlined" onclick={handleCancel} disabled={isSaving || !hasChanges()}>
-                  Cancel
-                </Button>
-              </div>
-            </Paper>
-          </>
-        )}
+        <CacheView
+          cache={usersService.userCache}
+          args={[props.username]}
+          content={UserDetailsContent}
+          loader={<Skeleton />}
+          error={(err, retry) => <GenericErrorPage error={err} retry={async () => retry()} />}
+        />
       </div>
     )
   },

--- a/frontend/src/pages/admin/user-details.tsx
+++ b/frontend/src/pages/admin/user-details.tsx
@@ -16,6 +16,73 @@ type RoleChange = {
 
 const UserDetailsContent = Shade<{ data: CacheWithValue<User> }>({
   shadowDomName: 'user-details-content',
+  css: {
+    '& .section-title': {
+      marginTop: '0',
+      marginBottom: '16px',
+      color: 'var(--theme-text-primary)',
+    },
+    '& .info-grid': {
+      display: 'grid',
+      gridTemplateColumns: '150px 1fr',
+      gap: '12px',
+      alignItems: 'center',
+    },
+    '& .info-label': {
+      color: 'var(--theme-text-secondary)',
+      fontWeight: '500',
+    },
+    '& .info-value': {
+      color: 'var(--theme-text-primary)',
+    },
+    '& .roles-container': {
+      marginBottom: '16px',
+    },
+    '& .roles-list': {
+      display: 'flex',
+      gap: '8px',
+      flexWrap: 'wrap',
+      minHeight: '32px',
+    },
+    '& .no-roles': {
+      color: 'var(--theme-text-secondary)',
+      fontStyle: 'italic',
+    },
+    '& .add-role-container': {
+      marginBottom: '16px',
+    },
+    '& .add-role-label': {
+      display: 'block',
+      marginBottom: '8px',
+      color: 'var(--theme-text-secondary)',
+      fontWeight: '500',
+      fontSize: '14px',
+    },
+    '& .add-role-select': {
+      padding: '8px 12px',
+      fontSize: '14px',
+      borderRadius: '4px',
+      border: '1px solid var(--theme-border-default)',
+      backgroundColor: 'var(--theme-background-paper)',
+      color: 'var(--theme-text-primary)',
+      cursor: 'pointer',
+      minWidth: '200px',
+    },
+    '& .validation-error': {
+      color: 'var(--theme-error-main)',
+      backgroundColor: 'rgba(244, 67, 54, 0.1)',
+      padding: '12px',
+      borderRadius: '4px',
+      marginBottom: '16px',
+      fontSize: '14px',
+    },
+    '& .button-row': {
+      display: 'flex',
+      gap: '12px',
+      borderTop: '1px solid var(--theme-border-default)',
+      paddingTop: '16px',
+    },
+  },
   render: ({ props, injector, useObservable, useDisposable }) => {
     const usersService = injector.getInstance(UsersService)
     const notyService = injector.getInstance(NotyService)
@@ -268,71 +335,6 @@ export const UserDetailsPage = Shade<UserDetailsPageProps>({
     '& .page-header h2': {
       margin: '0',
       color: 'var(--theme-text-primary)',
-    },
-    '& .section-title': {
-      marginTop: '0',
-      marginBottom: '16px',
-      color: 'var(--theme-text-primary)',
-    },
-    '& .info-grid': {
-      display: 'grid',
-      gridTemplateColumns: '150px 1fr',
-      gap: '12px',
-      alignItems: 'center',
-    },
-    '& .info-label': {
-      color: 'var(--theme-text-secondary)',
-      fontWeight: '500',
-    },
-    '& .info-value': {
-      color: 'var(--theme-text-primary)',
-    },
-    '& .roles-container': {
-      marginBottom: '16px',
-    },
-    '& .roles-list': {
-      display: 'flex',
-      gap: '8px',
-      flexWrap: 'wrap',
-      minHeight: '32px',
-    },
-    '& .no-roles': {
-      color: 'var(--theme-text-secondary)',
-      fontStyle: 'italic',
-    },
-    '& .add-role-container': {
-      marginBottom: '16px',
-    },
-    '& .add-role-label': {
-      display: 'block',
-      marginBottom: '8px',
-      color: 'var(--theme-text-secondary)',
-      fontWeight: '500',
-      fontSize: '14px',
-    },
-    '& .add-role-select': {
-      padding: '8px 12px',
-      fontSize: '14px',
-      borderRadius: '4px',
-      border: '1px solid var(--theme-border-default)',
-      backgroundColor: 'var(--theme-background-paper)',
-      color: 'var(--theme-text-primary)',
-      cursor: 'pointer',
-      minWidth: '200px',
-    },
-    '& .validation-error': {
-      color: 'var(--theme-error-main)',
-      backgroundColor: 'rgba(244, 67, 54, 0.1)',
-      padding: '12px',
-      borderRadius: '4px',
-      marginBottom: '16px',
-      fontSize: '14px',
-    },
-    '& .button-row': {
-      display: 'flex',
-      gap: '12px',
-      borderTop: '1px solid var(--theme-border-default)',
-      paddingTop: '16px',
     },
   },
   render: ({ props, injector }) => {

--- a/frontend/src/pages/admin/user-list.spec.tsx
+++ b/frontend/src/pages/admin/user-list.spec.tsx
@@ -1,40 +1,47 @@
+import { Cache } from '@furystack/cache'
+import type { GetCollectionResult } from '@furystack/rest'
 import { Injector } from '@furystack/inject'
 import { LocationService, createComponent, flushUpdates, initializeShadeRoot } from '@furystack/shades'
-import { ObservableValue } from '@furystack/utils'
 import type { User } from 'common'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { UsersService } from '../../services/users-service.js'
-import { type CacheState, createMockUser } from '../../test-utils/user-test-helpers.js'
+import { createMockUser } from '../../test-utils/user-test-helpers.js'
 import { UserListPage } from './user-list.js'
 
 describe('UserListPage', () => {
   let injector: Injector
   let mockUsersService: {
-    findUsersAsObservable: ReturnType<typeof vi.fn>
-    findUsers: ReturnType<typeof vi.fn>
-    userQueryCache: { flushAll: ReturnType<typeof vi.fn> }
+    userQueryCache: Cache<GetCollectionResult<User>, [Record<string, unknown>]>
   }
-  let usersObservable: ObservableValue<CacheState<{ count: number; entries: User[] }>>
+
+  const defaultUsers = [createMockUser('user1@example.com', ['admin']), createMockUser('user2@example.com', ['viewer'])]
+
+  const seedUsersCache = (entries: User[], count?: number) => {
+    mockUsersService.userQueryCache.setExplicitValue({
+      loadArgs: [{}],
+      value: {
+        status: 'loaded',
+        value: { count: count ?? entries.length, entries },
+        updatedAt: new Date(),
+      },
+    })
+  }
 
   beforeEach(() => {
     document.body.innerHTML = '<div id="root"></div>'
 
-    usersObservable = new ObservableValue<CacheState<{ count: number; entries: User[] }>>({
-      status: 'loaded',
-      value: {
-        count: 2,
-        entries: [createMockUser('user1@example.com', ['admin']), createMockUser('user2@example.com', ['viewer'])],
-      },
-      updatedAt: new Date(),
+    const userQueryCache = new Cache<GetCollectionResult<User>, [Record<string, unknown>]>({
+      capacity: 10,
+      load: vi.fn().mockResolvedValue({ count: 2, entries: defaultUsers }),
+    })
+
+    userQueryCache.setExplicitValue({
+      loadArgs: [{}],
+      value: { status: 'loaded', value: { count: 2, entries: defaultUsers }, updatedAt: new Date() },
     })
 
     mockUsersService = {
-      findUsersAsObservable: vi.fn().mockReturnValue(usersObservable),
-      findUsers: vi.fn().mockResolvedValue({
-        count: 2,
-        entries: [createMockUser('user1@example.com', ['admin']), createMockUser('user2@example.com', ['viewer'])],
-      }),
-      userQueryCache: { flushAll: vi.fn() },
+      userQueryCache,
     }
 
     injector = new Injector()
@@ -63,8 +70,14 @@ describe('UserListPage', () => {
       expect(page?.textContent).toContain('Manage user accounts and their roles.')
     })
 
-    it('should display loading state', async () => {
-      usersObservable.setValue({ status: 'loading' })
+    it('should display loader when loading', async () => {
+      const neverResolvingCache = new Cache<GetCollectionResult<User>, [Record<string, unknown>]>({
+        capacity: 10,
+        load: () => new Promise(() => {}),
+      })
+      mockUsersService.userQueryCache = neverResolvingCache
+
+      injector.setExplicitInstance(mockUsersService as unknown as UsersService, UsersService)
 
       const rootElement = document.getElementById('root') as HTMLDivElement
 
@@ -76,30 +89,14 @@ describe('UserListPage', () => {
       await flushUpdates()
 
       const page = document.querySelector('user-list-page')
-      expect(page?.textContent).toContain('Loading users...')
+      const skeleton = page?.querySelector('shade-skeleton')
+      expect(skeleton).toBeTruthy()
     })
 
-    it('should display loading state as loading', async () => {
-      usersObservable.setValue({ status: 'loading' })
-
-      const rootElement = document.getElementById('root') as HTMLDivElement
-
-      initializeShadeRoot({
-        injector,
-        rootElement,
-        jsxElement: <UserListPage />,
-      })
-      await flushUpdates()
-
-      const page = document.querySelector('user-list-page')
-      expect(page?.textContent).toContain('Loading users...')
-    })
-
-    it('should display error state with retry button', async () => {
-      usersObservable.setValue({
-        status: 'failed',
-        error: new Error('Network error'),
-        updatedAt: new Date(),
+    it('should display error state', async () => {
+      mockUsersService.userQueryCache.setExplicitValue({
+        loadArgs: [{}],
+        value: { status: 'failed', error: new Error('Network error'), updatedAt: new Date() },
       })
 
       const rootElement = document.getElementById('root') as HTMLDivElement
@@ -110,33 +107,10 @@ describe('UserListPage', () => {
         jsxElement: <UserListPage />,
       })
       await flushUpdates()
-
-      const page = document.querySelector('user-list-page')
-      expect(page?.textContent).toContain('Error: Network error')
-
-      // Button component renders a button element with content in shadow DOM
-      const retryButton = page?.querySelector('button')
-      expect(retryButton).toBeTruthy()
-    })
-
-    it('should display error message for non-Error objects', async () => {
-      usersObservable.setValue({
-        status: 'failed',
-        error: 'string error',
-        updatedAt: new Date(),
-      })
-
-      const rootElement = document.getElementById('root') as HTMLDivElement
-
-      initializeShadeRoot({
-        injector,
-        rootElement,
-        jsxElement: <UserListPage />,
-      })
       await flushUpdates()
 
       const page = document.querySelector('user-list-page')
-      expect(page?.textContent).toContain('Failed to load users')
+      expect(page?.textContent).toContain('Network error')
     })
   })
 
@@ -192,18 +166,11 @@ describe('UserListPage', () => {
       const page = document.querySelector('user-list-page')
       const roleTags = page?.querySelectorAll('role-tag')
 
-      expect(roleTags?.length).toBe(2) // One for admin, one for viewer
+      expect(roleTags?.length).toBe(2)
     })
 
     it('should display "No roles" message for user without roles', async () => {
-      usersObservable.setValue({
-        status: 'loaded',
-        value: {
-          count: 1,
-          entries: [createMockUser('noRoles@example.com', [])],
-        },
-        updatedAt: new Date(),
-      })
+      seedUsersCache([createMockUser('noRoles@example.com', [])])
 
       const rootElement = document.getElementById('root') as HTMLDivElement
 
@@ -219,14 +186,7 @@ describe('UserListPage', () => {
     })
 
     it('should display empty state when no users exist', async () => {
-      usersObservable.setValue({
-        status: 'loaded',
-        value: {
-          count: 0,
-          entries: [],
-        },
-        updatedAt: new Date(),
-      })
+      seedUsersCache([], 0)
 
       const rootElement = document.getElementById('root') as HTMLDivElement
 
@@ -252,11 +212,9 @@ describe('UserListPage', () => {
       await flushUpdates()
 
       const page = document.querySelector('user-list-page')
-      // Button component renders button elements within table rows
       const editButtons = page?.querySelectorAll('tbody button')
 
       expect(editButtons?.length).toBe(2)
-      // Verify buttons exist (content is in shadow DOM)
       expect(editButtons?.[0]).toBeTruthy()
       expect(editButtons?.[1]).toBeTruthy()
     })
@@ -304,14 +262,7 @@ describe('UserListPage', () => {
     })
 
     it('should encode username in URL to handle special characters', async () => {
-      usersObservable.setValue({
-        status: 'loaded',
-        value: {
-          count: 1,
-          entries: [createMockUser('user+special@example.com', ['admin'])],
-        },
-        updatedAt: new Date(),
-      })
+      seedUsersCache([createMockUser('user+special@example.com', ['admin'])])
 
       const rootElement = document.getElementById('root') as HTMLDivElement
 
@@ -327,47 +278,6 @@ describe('UserListPage', () => {
       row.click()
 
       expect(window.location.pathname).toBe('/app-settings/users/user%2Bspecial%40example.com')
-    })
-  })
-
-  describe('retry functionality', () => {
-    it('should flush cache and refetch when retry is clicked', async () => {
-      usersObservable.setValue({
-        status: 'failed',
-        error: new Error('Network error'),
-        updatedAt: new Date(),
-      })
-
-      const rootElement = document.getElementById('root') as HTMLDivElement
-
-      initializeShadeRoot({
-        injector,
-        rootElement,
-        jsxElement: <UserListPage />,
-      })
-      await flushUpdates()
-
-      const page = document.querySelector('user-list-page')
-      const retryButton = page?.querySelector('button') as HTMLButtonElement
-      retryButton.click()
-
-      expect(mockUsersService.userQueryCache.flushAll).toHaveBeenCalled()
-      expect(mockUsersService.findUsers).toHaveBeenCalledWith({})
-    })
-  })
-
-  describe('service integration', () => {
-    it('should call findUsersAsObservable on render', async () => {
-      const rootElement = document.getElementById('root') as HTMLDivElement
-
-      initializeShadeRoot({
-        injector,
-        rootElement,
-        jsxElement: <UserListPage />,
-      })
-      await flushUpdates()
-
-      expect(mockUsersService.findUsersAsObservable).toHaveBeenCalledWith({})
     })
   })
 })

--- a/frontend/src/pages/admin/user-list.tsx
+++ b/frontend/src/pages/admin/user-list.tsx
@@ -10,6 +10,61 @@ import { UsersService } from '../../services/users-service.js'
 
 const UserListContent = Shade<{ data: CacheWithValue<GetCollectionResult<User>> }>({
   shadowDomName: 'user-list-content',
+  css: {
+    '& .users-table': {
+      width: '100%',
+      borderCollapse: 'collapse',
+      fontSize: '14px',
+    },
+    '& thead tr': {
+      backgroundColor: 'var(--theme-background-default)',
+      borderBottom: '1px solid var(--theme-border-default)',
+    },
+    '& th': {
+      padding: '12px 16px',
+      textAlign: 'left',
+      fontWeight: '600',
+      color: 'var(--theme-text-primary)',
+    },
+    '& th.actions-col': {
+      textAlign: 'right',
+    },
+    '& tbody tr': {
+      borderBottom: '1px solid var(--theme-border-default)',
+      cursor: 'pointer',
+      transition: 'background-color 0.15s ease',
+    },
+    '& tbody tr:hover': {
+      backgroundColor: 'var(--theme-background-default)',
+    },
+    '& td': {
+      padding: '12px 16px',
+    },
+    '& .username-cell': {
+      color: 'var(--theme-text-primary)',
+      fontWeight: '500',
+    },
+    '& .roles-cell': {
+      display: 'flex',
+      gap: '8px',
+      flexWrap: 'wrap',
+    },
+    '& .no-roles': {
+      color: 'var(--theme-text-secondary)',
+      fontStyle: 'italic',
+    },
+    '& .created-cell': {
+      color: 'var(--theme-text-secondary)',
+    },
+    '& .actions-cell': {
+      textAlign: 'right',
+    },
+    '& .empty-row td': {
+      padding: '24px 16px',
+      textAlign: 'center',
+      color: 'var(--theme-text-secondary)',
+    },
+  },
   render: ({ props, injector }) => {
     const usersState = props.data
 
@@ -94,59 +149,6 @@ export const UserListPage = Shade<UserListPageProps>({
     },
     '& .page-description': {
       marginBottom: '24px',
-      color: 'var(--theme-text-secondary)',
-    },
-    '& .users-table': {
-      width: '100%',
-      borderCollapse: 'collapse',
-      fontSize: '14px',
-    },
-    '& thead tr': {
-      backgroundColor: 'var(--theme-background-default)',
-      borderBottom: '1px solid var(--theme-border-default)',
-    },
-    '& th': {
-      padding: '12px 16px',
-      textAlign: 'left',
-      fontWeight: '600',
-      color: 'var(--theme-text-primary)',
-    },
-    '& th.actions-col': {
-      textAlign: 'right',
-    },
-    '& tbody tr': {
-      borderBottom: '1px solid var(--theme-border-default)',
-      cursor: 'pointer',
-      transition: 'background-color 0.15s ease',
-    },
-    '& tbody tr:hover': {
-      backgroundColor: 'var(--theme-background-default)',
-    },
-    '& td': {
-      padding: '12px 16px',
-    },
-    '& .username-cell': {
-      color: 'var(--theme-text-primary)',
-      fontWeight: '500',
-    },
-    '& .roles-cell': {
-      display: 'flex',
-      gap: '8px',
-      flexWrap: 'wrap',
-    },
-    '& .no-roles': {
-      color: 'var(--theme-text-secondary)',
-      fontStyle: 'italic',
-    },
-    '& .created-cell': {
-      color: 'var(--theme-text-secondary)',
-    },
-    '& .actions-cell': {
-      textAlign: 'right',
-    },
-    '& .empty-row td': {
-      padding: '24px 16px',
-      textAlign: 'center',
       color: 'var(--theme-text-secondary)',
     },
   },

--- a/frontend/src/pages/admin/user-list.tsx
+++ b/frontend/src/pages/admin/user-list.tsx
@@ -1,8 +1,81 @@
+import type { CacheWithValue } from '@furystack/cache'
+import type { GetCollectionResult } from '@furystack/rest'
 import { createComponent, Shade } from '@furystack/shades'
-import { Button, Paper } from '@furystack/shades-common-components'
+import { Button, CacheView, Paper, Skeleton } from '@furystack/shades-common-components'
+import type { User } from 'common'
 import { navigateToRoute } from '../../navigate-to-route.js'
 import { RoleTag } from '../../components/role-tag/index.js'
+import { GenericErrorPage } from '../../components/generic-error.js'
 import { UsersService } from '../../services/users-service.js'
+
+const UserListContent = Shade<{ data: CacheWithValue<GetCollectionResult<User>> }>({
+  shadowDomName: 'user-list-content',
+  render: ({ props, injector }) => {
+    const usersState = props.data
+
+    const navigateToUser = (username: string) => {
+      navigateToRoute(injector, '/app-settings/users/:username', { username })
+    }
+
+    const formatDate = (dateString: string) => {
+      return new Date(dateString).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    }
+
+    return (
+      <Paper elevation={1} style={{ padding: '0', overflow: 'hidden' }}>
+        <table className="users-table">
+          <thead>
+            <tr>
+              <th>Username</th>
+              <th>Roles</th>
+              <th>Created</th>
+              <th className="actions-col">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {usersState.value.entries.map((user) => (
+              <tr onclick={() => navigateToUser(user.username)}>
+                <td className="username-cell">{user.username}</td>
+                <td>
+                  <div className="roles-cell">
+                    {user.roles.length > 0 ? (
+                      user.roles.map((roleName) => <RoleTag roleName={roleName} variant="default" />)
+                    ) : (
+                      <span className="no-roles">No roles</span>
+                    )}
+                  </div>
+                </td>
+                <td className="created-cell">{formatDate(user.createdAt)}</td>
+                <td className="actions-cell">
+                  <Button
+                    variant="outlined"
+                    onclick={(e) => {
+                      e.stopPropagation()
+                      navigateToUser(user.username)
+                    }}
+                  >
+                    Edit
+                  </Button>
+                </td>
+              </tr>
+            ))}
+            {usersState.value.entries.length === 0 && (
+              <tr className="empty-row">
+                <td colSpan={4}>No users found.</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </Paper>
+    )
+  },
+})
 
 type UserListPageProps = Record<string, never>
 
@@ -22,12 +95,6 @@ export const UserListPage = Shade<UserListPageProps>({
     '& .page-description': {
       marginBottom: '24px',
       color: 'var(--theme-text-secondary)',
-    },
-    '& .loading-text': {
-      color: 'var(--theme-text-secondary)',
-    },
-    '& .error-text': {
-      color: 'var(--theme-error-main)',
     },
     '& .users-table': {
       width: '100%',
@@ -83,102 +150,20 @@ export const UserListPage = Shade<UserListPageProps>({
       color: 'var(--theme-text-secondary)',
     },
   },
-  render: ({ injector, useObservable }) => {
+  render: ({ injector }) => {
     const usersService = injector.getInstance(UsersService)
-
-    const [usersState] = useObservable('users', usersService.findUsersAsObservable({}))
-
-    const navigateToUser = (username: string) => {
-      navigateToRoute(injector, '/app-settings/users/:username', { username })
-    }
-
-    const formatDate = (dateString: string) => {
-      return new Date(dateString).toLocaleDateString(undefined, {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-      })
-    }
-
-    const handleRetry = () => {
-      usersService.userQueryCache.flushAll()
-      void usersService.findUsers({})
-    }
-
-    const getErrorMessage = (error: unknown): string => {
-      if (error instanceof Error) return error.message
-      return 'Failed to load users'
-    }
 
     return (
       <div className="page-container">
         <h2 className="page-title">👥 Users</h2>
         <p className="page-description">Manage user accounts and their roles.</p>
-
-        {(usersState.status === 'loading' || usersState.status === 'obsolete') && (
-          <Paper elevation={1} style={{ padding: '24px' }}>
-            <p className="loading-text">Loading users...</p>
-          </Paper>
-        )}
-
-        {usersState.status === 'failed' && (
-          <Paper elevation={1} style={{ padding: '24px' }}>
-            <p className="error-text">Error: {getErrorMessage(usersState.error)}</p>
-            <Button variant="outlined" onclick={handleRetry} style={{ marginTop: '12px' }}>
-              Retry
-            </Button>
-          </Paper>
-        )}
-
-        {usersState.status === 'loaded' && (
-          <Paper elevation={1} style={{ padding: '0', overflow: 'hidden' }}>
-            <table className="users-table">
-              <thead>
-                <tr>
-                  <th>Username</th>
-                  <th>Roles</th>
-                  <th>Created</th>
-                  <th className="actions-col">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {usersState.value.entries.map((user) => (
-                  <tr onclick={() => navigateToUser(user.username)}>
-                    <td className="username-cell">{user.username}</td>
-                    <td>
-                      <div className="roles-cell">
-                        {user.roles.length > 0 ? (
-                          user.roles.map((roleName) => <RoleTag roleName={roleName} variant="default" />)
-                        ) : (
-                          <span className="no-roles">No roles</span>
-                        )}
-                      </div>
-                    </td>
-                    <td className="created-cell">{formatDate(user.createdAt)}</td>
-                    <td className="actions-cell">
-                      <Button
-                        variant="outlined"
-                        onclick={(e) => {
-                          e.stopPropagation()
-                          navigateToUser(user.username)
-                        }}
-                      >
-                        Edit
-                      </Button>
-                    </td>
-                  </tr>
-                ))}
-                {usersState.value.entries.length === 0 && (
-                  <tr className="empty-row">
-                    <td colSpan={4}>No users found.</td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
-          </Paper>
-        )}
+        <CacheView
+          cache={usersService.userQueryCache}
+          args={[{}]}
+          content={UserListContent}
+          loader={<Skeleton />}
+          error={(err, retry) => <GenericErrorPage error={err} retry={async () => retry()} />}
+        />
       </div>
     )
   },

--- a/frontend/src/pages/ai/ai-chat-list.tsx
+++ b/frontend/src/pages/ai/ai-chat-list.tsx
@@ -1,27 +1,18 @@
+import type { CacheWithValue } from '@furystack/cache'
+import type { GetCollectionResult } from '@furystack/rest'
 import { createComponent, Shade } from '@furystack/shades'
-import { Button, Paper } from '@furystack/shades-common-components'
+import { Button, CacheView, Paper, Skeleton } from '@furystack/shades-common-components'
 import type { AiChat } from 'common'
 import { ErrorDisplay } from '../../components/error-display.js'
 import { AiChatService } from './ai-chat-service.js'
 
-export const AiChatList = Shade<{ selectedChatId?: string; onSelect: (chat: AiChat) => void }>({
-  shadowDomName: 'pi-rat-ai-chat-list',
-  render: ({ injector, useObservable, props }) => {
-    const aiChatService = injector.getInstance(AiChatService)
-
-    const [chatList] = useObservable('chatList', aiChatService.getAiChatsAsObservable({}))
-
-    if (chatList.status === 'loading') {
-      return <div>Loading...</div>
-    }
-    if (chatList.status === 'failed') {
-      return <ErrorDisplay error={chatList.error} />
-    }
-
-    if (chatList.status === 'obsolete') {
-      void aiChatService.getAiChats({})
-    }
-
+const AiChatListContent = Shade<{
+  data: CacheWithValue<GetCollectionResult<AiChat>>
+  selectedChatId?: string
+  onSelect: (chat: AiChat) => void
+}>({
+  shadowDomName: 'pi-rat-ai-chat-list-content',
+  render: ({ props }) => {
     return (
       <Paper style={{ padding: '16px', height: 'calc(100% - 48px)' }}>
         <h3>Chats</h3>
@@ -34,7 +25,7 @@ export const AiChatList = Shade<{ selectedChatId?: string; onSelect: (chat: AiCh
             padding: '8px',
           }}
         >
-          {chatList.value.entries.map((chat) => (
+          {props.data.value.entries.map((chat) => (
             <Button
               variant={props.selectedChatId === chat.id ? 'contained' : undefined}
               onclick={() => {
@@ -46,6 +37,24 @@ export const AiChatList = Shade<{ selectedChatId?: string; onSelect: (chat: AiCh
           ))}
         </div>
       </Paper>
+    )
+  },
+})
+
+export const AiChatList = Shade<{ selectedChatId?: string; onSelect: (chat: AiChat) => void }>({
+  shadowDomName: 'pi-rat-ai-chat-list',
+  render: ({ injector, props }) => {
+    const aiChatService = injector.getInstance(AiChatService)
+
+    return (
+      <CacheView
+        cache={aiChatService.aiChatQueryCache}
+        args={[{}]}
+        content={AiChatListContent}
+        contentProps={{ selectedChatId: props.selectedChatId, onSelect: props.onSelect }}
+        loader={<Skeleton />}
+        error={(err) => <ErrorDisplay error={err} />}
+      />
     )
   },
 })

--- a/frontend/src/pages/file-browser/drive-selector.tsx
+++ b/frontend/src/pages/file-browser/drive-selector.tsx
@@ -1,36 +1,30 @@
+import type { CacheWithValue } from '@furystack/cache'
+import type { GetCollectionResult } from '@furystack/rest'
 import { createComponent, Shade } from '@furystack/shades'
+import { CacheView, Skeleton } from '@furystack/shades-common-components'
+import type { Drive } from 'common'
 import { DrivesService } from '../../services/drives-service.js'
 import { ErrorDisplay } from '../../components/error-display.js'
 import type { DriveLocation } from './index.js'
 
-export const DriveSelector = Shade<{
+const DriveSelectorContent = Shade<{
+  data: CacheWithValue<GetCollectionResult<Drive>>
   searchStateKey: string
   defaultDriveLetter: string
 }>({
-  shadowDomName: 'drive-selector',
-  render: ({ props, useObservable, injector, useSearchState }) => {
+  shadowDomName: 'drive-selector-content',
+  render: ({ props, useSearchState }) => {
     const [currentDrive, setCurrentDrive] = useSearchState(props.searchStateKey, {
       path: '/',
       letter: props.defaultDriveLetter,
     } as DriveLocation)
-
-    const drivesService = injector.getInstance(DrivesService)
-    const [availableDrives] = useObservable('availableDrives', drivesService.getVolumesAsObservable({}))
-
-    if (availableDrives.status === 'loading') {
-      return null // TODO: Skeleton
-    }
-
-    if (availableDrives.status === 'failed') {
-      return <ErrorDisplay error={availableDrives.error} />
-    }
 
     return (
       <select
         onchange={(ev) => {
           const { value } = ev.target as HTMLOptionElement
 
-          if (currentDrive.letter !== value && availableDrives.value?.entries.find((e) => e.letter === value)) {
+          if (currentDrive.letter !== value && props.data.value.entries.find((e) => e.letter === value)) {
             setCurrentDrive({
               letter: value,
               path: '/',
@@ -38,12 +32,33 @@ export const DriveSelector = Shade<{
           }
         }}
       >
-        {availableDrives.value.entries.map((r) => (
+        {props.data.value.entries.map((r) => (
           <option value={r.letter} selected={currentDrive.letter === r.letter}>
             {r.letter}
           </option>
         ))}
       </select>
+    )
+  },
+})
+
+export const DriveSelector = Shade<{
+  searchStateKey: string
+  defaultDriveLetter: string
+}>({
+  shadowDomName: 'drive-selector',
+  render: ({ props, injector }) => {
+    const drivesService = injector.getInstance(DrivesService)
+
+    return (
+      <CacheView
+        cache={drivesService.volumesCache}
+        args={[{}]}
+        content={DriveSelectorContent}
+        contentProps={{ searchStateKey: props.searchStateKey, defaultDriveLetter: props.defaultDriveLetter }}
+        loader={<Skeleton />}
+        error={(err) => <ErrorDisplay error={err} />}
+      />
     )
   },
 })

--- a/frontend/src/pages/movies/movie-overview.tsx
+++ b/frontend/src/pages/movies/movie-overview.tsx
@@ -179,6 +179,7 @@ export const MovieOverview = Shade<{ imdbId: string }>({
         args={[props.imdbId]}
         content={MovieOverviewContent}
         loader={<Skeleton />}
+        error={() => <>:(</>}
       />
     )
   },

--- a/frontend/src/pages/movies/movie-overview.tsx
+++ b/frontend/src/pages/movies/movie-overview.tsx
@@ -1,7 +1,9 @@
+import type { CacheWithValue } from '@furystack/cache'
 import { isLoadedCacheResult } from '@furystack/cache'
 import { serializeToQueryString } from '@furystack/rest'
 import { createComponent, ScreenService, Shade } from '@furystack/shades'
-import { Button, promisifyAnimation, Skeleton } from '@furystack/shades-common-components'
+import { Button, CacheView, promisifyAnimation, Skeleton } from '@furystack/shades-common-components'
+import type { Movie } from 'common'
 import { navigateToRoute } from '../../navigate-to-route.js'
 import { MovieFilesService } from '../../services/movie-files-service.js'
 import { MoviesService } from '../../services/movies-service.js'
@@ -89,85 +91,95 @@ export const PlayButtons = Shade<{ imdbId: string }>({
   },
 })
 
-export const MovieOverview = Shade<{ imdbId: string }>({
-  shadowDomName: 'shade-movie-overview',
+const MovieOverviewContent = Shade<{ data: CacheWithValue<Movie> }>({
+  shadowDomName: 'shade-movie-overview-content',
   render: ({ props, useObservable, injector, useRef }) => {
     const imgRef = useRef<HTMLImageElement>('posterImg')
     const [currentUser] = useObservable('currentUser', injector.getInstance(SessionService).currentUser)
     const [isDesktop] = useObservable('isDesktop', injector.getInstance(ScreenService).screenSize.atLeast.md)
-    const movieService = injector.getInstance(MoviesService)
 
-    const [movieResult] = useObservable('movie', movieService.getMovieAsObservable(props.imdbId))
-
-    if (isLoadedCacheResult(movieResult)) {
-      setTimeout(() => {
-        void promisifyAnimation(
-          imgRef.current,
-          [
-            { opacity: 0, transform: 'scale(0.85)' },
-            { opacity: 1, transform: 'scale(1)' },
-          ],
-          {
-            easing: 'cubic-bezier(0.415, 0.225, 0.375, 1.355)',
-            duration: 500,
-            direction: 'alternate',
-            fill: 'forwards',
-          },
-        )
-      }, 100)
-      const movie = movieResult.value
-      return (
-        <div style={{ width: '100%', height: 'calc(100% - 40px', paddingTop: '40px' }}>
-          <div
-            style={{
-              width: '100%',
-              height: '100%',
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'flex-start',
-              flexWrap: 'wrap',
-            }}
-          >
-            <div style={{ padding: '2em' }}>
-              <img
-                ref={imgRef}
-                src={movie.thumbnailImageUrl || ''}
-                alt={`thumbnail for ${movie.title}`}
-                style={{ boxShadow: '3px 3px 8px rgba(0,0,0,0.3)', borderRadius: '8px', opacity: '0' }}
-              />
-            </div>
-            <div style={{ padding: '2em', maxWidth: '800px', minWidth: isDesktop ? '550px' : undefined }}>
-              <h1>{movie.title}</h1>
-              <p style={{ fontSize: '0.8em' }}>
-                {movie.year?.toString()} &nbsp; {movie.genre}
-              </p>
-              <p style={{ textAlign: 'justify' }}>{movie.plot}</p>
-              <div>
-                <PlayButtons imdbId={movie.imdbId} />
-                {currentUser?.roles.includes('movie-admin') ? (
-                  <span>
-                    <Button
-                      onclick={() => {
-                        navigateToRoute(
-                          injector,
-                          '/entities/movies',
-                          {},
-                          {
-                            queryString: serializeToQueryString({ gedst: { mode: 'edit', currentId: movie.imdbId } }),
-                          },
-                        )
-                      }}
-                    >
-                      Edit
-                    </Button>
-                  </span>
-                ) : null}
-              </div>
+    setTimeout(() => {
+      void promisifyAnimation(
+        imgRef.current,
+        [
+          { opacity: 0, transform: 'scale(0.85)' },
+          { opacity: 1, transform: 'scale(1)' },
+        ],
+        {
+          easing: 'cubic-bezier(0.415, 0.225, 0.375, 1.355)',
+          duration: 500,
+          direction: 'alternate',
+          fill: 'forwards',
+        },
+      )
+    }, 100)
+    const movie = props.data.value
+    return (
+      <div style={{ width: '100%', height: 'calc(100% - 40px', paddingTop: '40px' }}>
+        <div
+          style={{
+            width: '100%',
+            height: '100%',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'flex-start',
+            flexWrap: 'wrap',
+          }}
+        >
+          <div style={{ padding: '2em' }}>
+            <img
+              ref={imgRef}
+              src={movie.thumbnailImageUrl || ''}
+              alt={`thumbnail for ${movie.title}`}
+              style={{ boxShadow: '3px 3px 8px rgba(0,0,0,0.3)', borderRadius: '8px', opacity: '0' }}
+            />
+          </div>
+          <div style={{ padding: '2em', maxWidth: '800px', minWidth: isDesktop ? '550px' : undefined }}>
+            <h1>{movie.title}</h1>
+            <p style={{ fontSize: '0.8em' }}>
+              {movie.year?.toString()} &nbsp; {movie.genre}
+            </p>
+            <p style={{ textAlign: 'justify' }}>{movie.plot}</p>
+            <div>
+              <PlayButtons imdbId={movie.imdbId} />
+              {currentUser?.roles.includes('movie-admin') ? (
+                <span>
+                  <Button
+                    onclick={() => {
+                      navigateToRoute(
+                        injector,
+                        '/entities/movies',
+                        {},
+                        {
+                          queryString: serializeToQueryString({ gedst: { mode: 'edit', currentId: movie.imdbId } }),
+                        },
+                      )
+                    }}
+                  >
+                    Edit
+                  </Button>
+                </span>
+              ) : null}
             </div>
           </div>
         </div>
-      )
-    }
-    return null
+      </div>
+    )
+  },
+})
+
+export const MovieOverview = Shade<{ imdbId: string }>({
+  shadowDomName: 'shade-movie-overview',
+  render: ({ props, injector }) => {
+    const movieService = injector.getInstance(MoviesService)
+
+    return (
+      <CacheView
+        cache={movieService.movieCache}
+        args={[props.imdbId]}
+        content={MovieOverviewContent}
+        loader={<Skeleton />}
+      />
+    )
   },
 })

--- a/frontend/src/services/config-service.ts
+++ b/frontend/src/services/config-service.ts
@@ -1,6 +1,7 @@
 import { Cache } from '@furystack/cache'
 import type { FindOptions } from '@furystack/core'
 import { Injectable, Injected } from '@furystack/inject'
+import { ResponseError } from '@furystack/rest-client-fetch'
 import type { Config, ConfigType } from 'common'
 import { ConfigApiClient } from './api-clients/config-api-client.js'
 
@@ -12,13 +13,20 @@ export class ConfigService {
   public configCache = new Cache({
     capacity: 50,
     load: async (id: ConfigType['id']) => {
-      const { result } = await this.configApiClient.call({
-        method: 'GET',
-        action: '/config/:id',
-        url: { id },
-        query: {},
-      })
-      return result
+      try {
+        const { result } = await this.configApiClient.call({
+          method: 'GET',
+          action: '/config/:id',
+          url: { id },
+          query: {},
+        })
+        return result
+      } catch (error) {
+        if (error instanceof ResponseError && error.response.status === 404) {
+          return { id, value: null } as unknown as Config
+        }
+        throw error
+      }
     },
   })
 

--- a/frontend/src/services/config-service.ts
+++ b/frontend/src/services/config-service.ts
@@ -9,7 +9,7 @@ export class ConfigService {
   @Injected(ConfigApiClient)
   declare private readonly configApiClient: ConfigApiClient
 
-  private configCache = new Cache({
+  public configCache = new Cache({
     capacity: 50,
     load: async (id: ConfigType['id']) => {
       const { result } = await this.configApiClient.call({

--- a/frontend/src/services/config-service.ts
+++ b/frontend/src/services/config-service.ts
@@ -60,9 +60,9 @@ export class ConfigService {
     id: TId,
     value: Extract<ConfigType, { id: TId }>['value'],
   ): Promise<Config> {
-    const existingConfig = await this.configCache.get(id)
+    const existingConfig = await this.configCache.get(id).catch(() => null)
 
-    if (existingConfig.value != null) {
+    if (existingConfig?.value != null) {
       await this.configApiClient.call({
         method: 'PATCH',
         action: '/config/:id',

--- a/frontend/src/services/config-service.ts
+++ b/frontend/src/services/config-service.ts
@@ -60,9 +60,9 @@ export class ConfigService {
     id: TId,
     value: Extract<ConfigType, { id: TId }>['value'],
   ): Promise<Config> {
-    const existingConfig = await this.configCache.get(id).catch(() => null)
+    const existingConfig = await this.configCache.get(id)
 
-    if (existingConfig) {
+    if (existingConfig.value != null) {
       await this.configApiClient.call({
         method: 'PATCH',
         action: '/config/:id',

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-jsdoc": "^62.7.1",
-    "eslint-plugin-playwright": "^2.7.1",
+    "eslint-plugin-playwright": "^2.8.0",
     "eslint-plugin-prettier": "^5.5.5",
     "husky": "^9.1.7",
     "jsdom": "^28.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -835,9 +835,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@furystack/shades-common-components@npm:^13.0.1":
-  version: 13.0.1
-  resolution: "@furystack/shades-common-components@npm:13.0.1"
+"@furystack/shades-common-components@npm:^13.1.0":
+  version: 13.1.0
+  resolution: "@furystack/shades-common-components@npm:13.1.0"
   dependencies:
     "@furystack/cache": "npm:^6.0.0"
     "@furystack/core": "npm:^15.2.2"
@@ -845,7 +845,7 @@ __metadata:
     "@furystack/shades": "npm:^12.2.4"
     "@furystack/utils": "npm:^8.1.10"
     path-to-regexp: "npm:^8.3.0"
-  checksum: 10c0/82591863555353daaec2a3a151393a65e9d377b1ddb2b10cddb06828d8eb5e0b7948c7ec3f7d191ae931a264a10edd20b53c785b84b6e51055e50669ed79f842
+  checksum: 10c0/d04ec670e45e5e3ffff4db8c06ea52fd35726d4f36b89885a8bfa845e50c5de43d1d6a9f6738d42f3bf234395c5f7702558b8217af725bc1aa3a906f985b077d
   languageName: node
   linkType: hard
 
@@ -4227,14 +4227,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-playwright@npm:^2.7.1":
-  version: 2.7.1
-  resolution: "eslint-plugin-playwright@npm:2.7.1"
+"eslint-plugin-playwright@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "eslint-plugin-playwright@npm:2.8.0"
   dependencies:
     globals: "npm:^17.3.0"
   peerDependencies:
     eslint: ">=8.40.0"
-  checksum: 10c0/efd45122b4d4e77608862f0f25a95200a0e367abbe6d53bdce38c59009c4b90edcf12b6f1c2b50e86b0addea56c68ad0c7767768b0a2a73d7f09a814b827df72
+  checksum: 10c0/64767f7a963fd78be5ab4dfb261a9b658e9b9835badf47825a70d1608fcfa420a53ca8a9ce874f830cf2bc10823e232b11ad9dc5b2ea5124193f805fa06bfc6b
   languageName: node
   linkType: hard
 
@@ -4602,7 +4602,7 @@ __metadata:
     "@furystack/rest": "npm:^8.0.40"
     "@furystack/rest-client-fetch": "npm:^8.0.40"
     "@furystack/shades": "npm:^12.2.4"
-    "@furystack/shades-common-components": "npm:^13.0.1"
+    "@furystack/shades-common-components": "npm:^13.1.0"
     "@furystack/shades-lottie": "npm:^8.0.7"
     "@furystack/utils": "npm:^8.1.10"
     "@types/marked": "npm:^6.0.0"
@@ -6930,7 +6930,7 @@ __metadata:
     eslint-config-prettier: "npm:^10.1.8"
     eslint-plugin-import: "npm:2.32.0"
     eslint-plugin-jsdoc: "npm:^62.7.1"
-    eslint-plugin-playwright: "npm:^2.7.1"
+    eslint-plugin-playwright: "npm:^2.8.0"
     eslint-plugin-prettier: "npm:^5.5.5"
     husky: "npm:^9.1.7"
     jsdom: "npm:^28.1.0"


### PR DESCRIPTION
## 🔄 Refactor: Migrate components to CacheView

Replace manual cache state handling (`isPendingCacheResult`/`isLoadedCacheResult`/`isFailedCacheResult`) with the `CacheView` component from `@furystack/shades-common-components`. Each affected component is split into a wrapper (provides `CacheView` with cache + args) and a content component (receives `data: CacheWithValue<T>`).

This reduces boilerplate, standardizes loading/error/content rendering, and leverages the framework's built-in cache subscription management.

### 📦 Changes

- Refactored 15 frontend components to use `CacheView`
- Made `ConfigService.configCache` public
- Added `GenericErrorPage` error handlers to admin settings and user management pages
- Bumped `@furystack/shades-common-components` ^13.0.1 → ^13.1.0
- Bumped `eslint-plugin-playwright` ^2.7.1 → ^2.8.0
