### PR TITLE
feat: form handling improvements

### DIFF
--- a/.yarn/changelogs/frontend.aff8d1dd.md
+++ b/.yarn/changelogs/frontend.aff8d1dd.md
@@ -1,0 +1,45 @@
+<!-- version-type: patch -->
+
+# frontend
+
+<!--
+FORMATTING GUIDE:
+
+### Detailed Entry (appears first when merging)
+
+Use h3 (###) and below for detailed entries with paragraphs, code examples, and lists.
+
+### Simple List Items
+
+- Simple changes can be added as list items
+- They are collected together at the bottom of each section
+
+TIP: When multiple changelog drafts are merged, heading-based entries
+appear before simple list items within each section.
+-->
+
+## ♻️ Refactoring
+
+### Extracted form validation into standalone type guard functions
+
+Inline `validate` callbacks across all form components have been replaced with exported, reusable type guard functions and explicit payload types. This removes `Record<string, unknown>` casts and manual `FormData` extraction in favor of strongly-typed `onSubmit` callbacks provided by the `Form` component.
+
+**Affected components:**
+
+- `Login` / `Register` - Extracted `isLoginPayload` and `isRegisterPayload` type guards
+- `WizardStep` - Now uses the `Form` component internally with a typed `onSubmit(data)` instead of raw `SubmitEvent` handling
+- `CreateAdminStep` / `AddDriveStep` - Replaced manual `new FormData()` + `Object.fromEntries()` extraction with typed form data via `WizardStep`
+- `AiSettings` / `IotSettings` / `OmdbSettings` / `StreamingSettings` - Extracted `isOllamaRawFormData`, `isIotRawFormData`, `isOmdbRawFormData`, and corresponding validation helpers
+- `AddChatButton` / `InviteButton` / `MessageInput` - Extracted `isAddChatPayload`, `isInvitePayload`, `isChatMessagePayload` type guards
+- `CreateAiChatButton` / `UserSettings` - Extracted `isCreateAiChatPayload` and `isPasswordResetPayload` type guards
+
+## 🧪 Tests
+
+- Added unit tests for `isLoginPayload` and `isRegisterPayload` validation logic
+- Added unit tests for `isCreateAdminPayload` covering field presence and password confirmation matching
+- Added unit tests for `isOllamaRawFormData` URL validation and `isIotRawFormData` numeric range constraints
+- Added unit tests for `isOmdbRawFormData` and streaming settings form validation
+- Added unit tests for `isChatMessagePayload`, `isAddChatPayload`, and `isInvitePayload` type guards
+- Added unit tests for `isCreateAiChatPayload` and `isPasswordResetPayload` validation
+- Added unit tests for `isAddDrivePayload` drive creation validation
+- Added unit tests for `WizardStep` verifying integration with the `Form` component and `validate` prop

--- a/.yarn/changelogs/pi-rat.aff8d1dd.md
+++ b/.yarn/changelogs/pi-rat.aff8d1dd.md
@@ -1,0 +1,27 @@
+<!-- version-type: patch -->
+
+# pi-rat
+
+<!--
+FORMATTING GUIDE:
+
+### Detailed Entry (appears first when merging)
+
+Use h3 (###) and below for detailed entries with paragraphs, code examples, and lists.
+
+### Simple List Items
+
+- Simple changes can be added as list items
+- They are collected together at the bottom of each section
+
+TIP: When multiple changelog drafts are merged, heading-based entries
+appear before simple list items within each section.
+-->
+
+## ♻️ Refactoring
+
+- Extracted inline form validation into standalone, exported type guard functions across all frontend form components, replacing `Record<string, unknown>` casts with explicit payload types and strongly-typed `onSubmit` callbacks
+
+## 🧪 Tests
+
+- Added unit tests for all extracted form validation type guards covering field presence, type checking, and cross-field constraints

--- a/.yarn/versions/aff8d1dd.yml
+++ b/.yarn/versions/aff8d1dd.yml
@@ -1,0 +1,3 @@
+releases:
+  frontend: patch
+  pi-rat: patch

--- a/e2e/file-browser.spec.ts
+++ b/e2e/file-browser.spec.ts
@@ -23,7 +23,7 @@ const createDrive = async (page: Page, tempPath: string, tempDriveLetter: string
   const submitButton = page.getByRole('button', { name: 'Finish' })
   await submitButton.click()
 
-  await assertAndDismissNoty(page, `Drive '${tempDriveLetter}' has been created succesfully`)
+  await assertAndDismissNoty(page, `Drive '${tempDriveLetter}' has been created successfully`)
 }
 
 const selectDrive = async (page: Page, driveLetter: string) => {

--- a/frontend/src/components/wizard-step.spec.tsx
+++ b/frontend/src/components/wizard-step.spec.tsx
@@ -250,6 +250,7 @@ describe('WizardStep', () => {
       const form = wizardStep?.querySelector('form')
 
       form?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+      await flushUpdates()
       expect(onNext).toHaveBeenCalledTimes(1)
     })
   })
@@ -265,7 +266,14 @@ describe('WizardStep', () => {
         injector,
         rootElement,
         jsxElement: (
-          <WizardStep title="Submit Test" currentPage={0} maxPages={3} onSubmit={onSubmit} onNext={onNext}>
+          <WizardStep
+            title="Submit Test"
+            currentPage={0}
+            maxPages={3}
+            validate={(data): data is Record<string, string> => typeof data === 'object' && data !== null}
+            onSubmit={onSubmit}
+            onNext={onNext}
+          >
             Content
           </WizardStep>
         ),
@@ -276,6 +284,7 @@ describe('WizardStep', () => {
       const form = wizardStep?.querySelector('form')
 
       form?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+      await flushUpdates()
       expect(onSubmit).toHaveBeenCalledTimes(1)
       expect(onNext).not.toHaveBeenCalled()
     })

--- a/frontend/src/components/wizard-step.tsx
+++ b/frontend/src/components/wizard-step.tsx
@@ -1,9 +1,16 @@
 import { createComponent, ScreenService, Shade } from '@furystack/shades'
 import type { WizardStepProps } from '@furystack/shades-common-components'
-import { Button, showParallax } from '@furystack/shades-common-components'
+import { Button, Form, showParallax } from '@furystack/shades-common-components'
+
+const defaultValidate = (formData: unknown): formData is Record<string, string> =>
+  typeof formData === 'object' && formData !== null
 
 export const WizardStep = Shade<
-  { title: string; onSubmit?: (ev: SubmitEvent) => void | Promise<void> } & WizardStepProps
+  {
+    title: string
+    validate?: (formData: unknown) => formData is Record<string, string>
+    onSubmit?: (formData: Record<string, string>) => void | Promise<void>
+  } & WizardStepProps
 >({
   shadowDomName: 'wizard-step',
   css: {
@@ -63,12 +70,12 @@ export const WizardStep = Shade<
     }
 
     return (
-      <form
+      <Form<Record<string, string>>
         ref={formRef}
-        onsubmit={async (ev) => {
-          ev.preventDefault()
+        validate={props.validate ?? defaultValidate}
+        onSubmit={async (data) => {
           if (props.onSubmit) {
-            await props.onSubmit(ev)
+            await props.onSubmit(data)
           } else {
             props.onNext?.()
           }
@@ -91,7 +98,7 @@ export const WizardStep = Shade<
             {props.currentPage < props.maxPages - 1 ? 'Next' : 'Finish'}
           </Button>
         </div>
-      </form>
+      </Form>
     )
   },
 })

--- a/frontend/src/components/wizard-step.tsx
+++ b/frontend/src/components/wizard-step.tsx
@@ -3,7 +3,9 @@ import type { WizardStepProps } from '@furystack/shades-common-components'
 import { Button, Form, showParallax } from '@furystack/shades-common-components'
 
 const defaultValidate = (formData: unknown): formData is Record<string, string> =>
-  typeof formData === 'object' && formData !== null
+  typeof formData === 'object' &&
+  formData !== null &&
+  Object.values(formData as Record<string, unknown>).every((v) => typeof v === 'string')
 
 export const WizardStep = Shade<
   {

--- a/frontend/src/installer/create-admin-step.spec.ts
+++ b/frontend/src/installer/create-admin-step.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { isCreateAdminPayload } from './create-admin-step.js'
+
+describe('isCreateAdminPayload', () => {
+  describe('valid data', () => {
+    it('returns true for valid payload', () => {
+      expect(
+        isCreateAdminPayload({
+          userName: 'admin@test.com',
+          password: 'secret123',
+          confirmPassword: 'secret123',
+        }),
+      ).toBe(true)
+    })
+
+    it('returns true for payload with extra fields', () => {
+      expect(
+        isCreateAdminPayload({
+          userName: 'admin@test.com',
+          password: 'secret123',
+          confirmPassword: 'secret123',
+          extra: 'field',
+        }),
+      ).toBe(true)
+    })
+  })
+
+  describe('primitives and nullish', () => {
+    it('returns false for null', () => {
+      expect(isCreateAdminPayload(null)).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+      expect(isCreateAdminPayload(undefined)).toBe(false)
+    })
+
+    it('returns false for string', () => {
+      expect(isCreateAdminPayload('hello')).toBe(false)
+    })
+
+    it('returns false for number', () => {
+      expect(isCreateAdminPayload(42)).toBe(false)
+    })
+  })
+
+  describe('missing fields', () => {
+    it('returns false when userName is missing', () => {
+      expect(isCreateAdminPayload({ password: 'secret123', confirmPassword: 'secret123' })).toBe(false)
+    })
+
+    it('returns false when password is missing', () => {
+      expect(isCreateAdminPayload({ userName: 'admin@test.com', confirmPassword: 'secret123' })).toBe(false)
+    })
+
+    it('returns false when confirmPassword is missing', () => {
+      expect(isCreateAdminPayload({ userName: 'admin@test.com', password: 'secret123' })).toBe(false)
+    })
+
+    it('returns false for empty object', () => {
+      expect(isCreateAdminPayload({})).toBe(false)
+    })
+  })
+
+  describe('empty string fields', () => {
+    it('returns false when userName is empty', () => {
+      expect(isCreateAdminPayload({ userName: '', password: 'secret123', confirmPassword: 'secret123' })).toBe(false)
+    })
+
+    it('returns false when password is empty', () => {
+      expect(isCreateAdminPayload({ userName: 'admin@test.com', password: '', confirmPassword: 'secret123' })).toBe(
+        false,
+      )
+    })
+
+    it('returns false when confirmPassword is empty', () => {
+      expect(isCreateAdminPayload({ userName: 'admin@test.com', password: 'secret123', confirmPassword: '' })).toBe(
+        false,
+      )
+    })
+  })
+
+  describe('wrong types', () => {
+    it('returns false when userName is not a string', () => {
+      expect(isCreateAdminPayload({ userName: 123, password: 'secret123', confirmPassword: 'secret123' })).toBe(false)
+    })
+
+    it('returns false when password is not a string', () => {
+      expect(isCreateAdminPayload({ userName: 'admin@test.com', password: 123, confirmPassword: 'secret123' })).toBe(
+        false,
+      )
+    })
+
+    it('returns false when confirmPassword is not a string', () => {
+      expect(isCreateAdminPayload({ userName: 'admin@test.com', password: 'secret123', confirmPassword: 123 })).toBe(
+        false,
+      )
+    })
+  })
+
+  describe('password mismatch', () => {
+    it('returns false when password and confirmPassword do not match', () => {
+      expect(
+        isCreateAdminPayload({
+          userName: 'admin@test.com',
+          password: 'secret123',
+          confirmPassword: 'different',
+        }),
+      ).toBe(false)
+    })
+  })
+})

--- a/frontend/src/installer/create-admin-step.tsx
+++ b/frontend/src/installer/create-admin-step.tsx
@@ -4,6 +4,26 @@ import { Input } from '@furystack/shades-common-components'
 import { WizardStep } from '../components/wizard-step.js'
 import { InstallApiClient } from '../services/api-clients/install-api-client.js'
 
+export type CreateAdminPayload = {
+  userName: string
+  password: string
+  confirmPassword: string
+}
+
+export const isCreateAdminPayload = (data: unknown): data is CreateAdminPayload => {
+  if (typeof data !== 'object' || data === null) return false
+  const d = data as Record<string, unknown>
+  return (
+    typeof d.userName === 'string' &&
+    d.userName.length > 0 &&
+    typeof d.password === 'string' &&
+    d.password.length > 0 &&
+    typeof d.confirmPassword === 'string' &&
+    d.confirmPassword.length > 0 &&
+    d.password === d.confirmPassword
+  )
+}
+
 export const CreateAdminStep = Shade<WizardStepProps>({
   shadowDomName: 'create-admin-step',
   render: ({ props, injector }) => {
@@ -11,19 +31,14 @@ export const CreateAdminStep = Shade<WizardStepProps>({
       <WizardStep
         title="Create the Super Admin user"
         {...props}
-        onSubmit={async (ev) => {
-          ev.preventDefault()
-          const form = ev.target as HTMLFormElement
-          const formData = new FormData(form)
-
-          const values = Object.fromEntries(formData.entries()) as { userName: string; password: string }
-
+        validate={isCreateAdminPayload}
+        onSubmit={async (data) => {
           await injector.getInstance(InstallApiClient).call({
             method: 'POST',
             action: '/install',
             body: {
-              username: values.userName.toString(),
-              password: values.password.toString(),
+              username: data.userName,
+              password: data.password,
             },
           })
 
@@ -65,7 +80,6 @@ export const CreateAdminStep = Shade<WizardStepProps>({
           required
           autocomplete="off"
         />
-        <input type="submit" style={{ display: 'none' }} />
       </WizardStep>
     )
   },

--- a/frontend/src/pages/admin/ai-settings-guards.spec.ts
+++ b/frontend/src/pages/admin/ai-settings-guards.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { isOllamaRawFormData, isValidUrl } from './ai-settings.js'
+
+describe('isValidUrl', () => {
+  it('returns true for empty string', () => {
+    expect(isValidUrl('')).toBe(true)
+  })
+
+  it('returns true for valid http URL', () => {
+    expect(isValidUrl('http://localhost:11434')).toBe(true)
+  })
+
+  it('returns true for valid https URL', () => {
+    expect(isValidUrl('https://example.com')).toBe(true)
+  })
+
+  it('returns false for ftp URL', () => {
+    expect(isValidUrl('ftp://example.com')).toBe(false)
+  })
+
+  it('returns false for invalid string', () => {
+    expect(isValidUrl('not-a-url')).toBe(false)
+  })
+
+  it('returns false for malformed URL', () => {
+    expect(isValidUrl('http://')).toBe(false)
+  })
+})
+
+describe('isOllamaRawFormData', () => {
+  describe('valid data', () => {
+    it('returns true for valid payload with http host', () => {
+      expect(isOllamaRawFormData({ host: 'http://localhost:11434' })).toBe(true)
+    })
+
+    it('returns true for valid payload with https host', () => {
+      expect(isOllamaRawFormData({ host: 'https://ollama.example.com' })).toBe(true)
+    })
+
+    it('returns true for empty host', () => {
+      expect(isOllamaRawFormData({ host: '' })).toBe(true)
+    })
+
+    it('returns true for payload with extra fields', () => {
+      expect(isOllamaRawFormData({ host: 'http://localhost:11434', extra: 'field' })).toBe(true)
+    })
+  })
+
+  describe('primitives and nullish', () => {
+    it('returns false for null', () => {
+      expect(isOllamaRawFormData(null)).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+      expect(isOllamaRawFormData(undefined)).toBe(false)
+    })
+
+    it('returns false for string', () => {
+      expect(isOllamaRawFormData('hello')).toBe(false)
+    })
+
+    it('returns false for number', () => {
+      expect(isOllamaRawFormData(42)).toBe(false)
+    })
+  })
+
+  describe('missing or invalid host', () => {
+    it('returns false when host is missing', () => {
+      expect(isOllamaRawFormData({})).toBe(false)
+    })
+
+    it('returns false when host is not a string', () => {
+      expect(isOllamaRawFormData({ host: 123 })).toBe(false)
+    })
+
+    it('returns false when host is invalid URL', () => {
+      expect(isOllamaRawFormData({ host: 'not-a-url' })).toBe(false)
+    })
+
+    it('returns false when host uses ftp protocol', () => {
+      expect(isOllamaRawFormData({ host: 'ftp://example.com' })).toBe(false)
+    })
+  })
+})

--- a/frontend/src/pages/admin/ai-settings.tsx
+++ b/frontend/src/pages/admin/ai-settings.tsx
@@ -105,9 +105,9 @@ const AiSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
           <Form<OllamaRawFormData>
             validate={(data): data is OllamaRawFormData => {
               const isValid = isOllamaRawFormData(data)
-              if (!isValid) {
-                validationErrorObservable.setValue('Please enter a valid URL (e.g., http://localhost:11434)')
-              }
+              validationErrorObservable.setValue(
+                isValid ? null : 'Please enter a valid URL (e.g., http://localhost:11434)',
+              )
               return isValid
             }}
             onSubmit={(data) => void handleSubmit(data)}

--- a/frontend/src/pages/admin/ai-settings.tsx
+++ b/frontend/src/pages/admin/ai-settings.tsx
@@ -8,7 +8,11 @@ import { ConfigService } from '../../services/config-service.js'
 
 type OllamaFormData = OllamaConfig['value']
 
-const isValidUrl = (urlString: string): boolean => {
+export type OllamaRawFormData = {
+  host: string
+}
+
+export const isValidUrl = (urlString: string): boolean => {
   if (urlString === '') return true
   try {
     const url = new URL(urlString)
@@ -16,6 +20,13 @@ const isValidUrl = (urlString: string): boolean => {
   } catch {
     return false
   }
+}
+
+export const isOllamaRawFormData = (data: unknown): data is OllamaRawFormData => {
+  if (typeof data !== 'object' || data === null) return false
+  const d = data as Record<string, unknown>
+  if (typeof d.host !== 'string') return false
+  return isValidUrl(d.host)
 }
 
 const AiSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
@@ -55,25 +66,11 @@ const AiSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
     const validationErrorObservable = useDisposable('validationError', () => new ObservableValue<string | null>(null))
     const [validationError] = useObservable('validationErrorValue', validationErrorObservable)
 
-    const validateForm = (formData: Record<string, unknown>): string | null => {
-      const host = (formData.host as string) ?? ''
-
-      if (host !== '' && !isValidUrl(host)) {
-        return 'Please enter a valid URL (e.g., http://localhost:11434)'
-      }
-      return null
-    }
-
-    const handleSubmit = async (formData: Record<string, unknown>) => {
-      const error = validateForm(formData)
-      if (error) {
-        validationErrorObservable.setValue(error)
-        return
-      }
+    const handleSubmit = async (formData: OllamaRawFormData) => {
       validationErrorObservable.setValue(null)
 
       const data: OllamaFormData = {
-        host: (formData.host as string) ?? '',
+        host: formData.host,
       }
 
       isLoadingObservable.setValue(true)
@@ -105,11 +102,13 @@ const AiSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
         <p className="page-description">Configure the connection to your Ollama server for AI-powered features.</p>
 
         <Paper elevation={1} style={{ padding: '24px' }}>
-          <Form<Record<string, unknown>>
-            validate={(data): data is Record<string, unknown> => {
-              const error = validateForm(data as Record<string, unknown>)
-              validationErrorObservable.setValue(error)
-              return error === null
+          <Form<OllamaRawFormData>
+            validate={(data): data is OllamaRawFormData => {
+              const isValid = isOllamaRawFormData(data)
+              if (!isValid) {
+                validationErrorObservable.setValue('Please enter a valid URL (e.g., http://localhost:11434)')
+              }
+              return isValid
             }}
             onSubmit={(data) => void handleSubmit(data)}
           >

--- a/frontend/src/pages/admin/iot-settings-guards.spec.ts
+++ b/frontend/src/pages/admin/iot-settings-guards.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_PING_INTERVAL_MS,
+  MAX_PING_TIMEOUT_MS,
+  MIN_PING_INTERVAL_MS,
+  MIN_PING_TIMEOUT_MS,
+  isIotRawFormData,
+  validateIotForm,
+} from './iot-settings.js'
+
+describe('validateIotForm', () => {
+  it('returns null for valid data', () => {
+    expect(validateIotForm({ pingIntervalMs: '30000', pingTimeoutMs: '3000' })).toBe(null)
+  })
+
+  it('returns error when ping interval is below minimum', () => {
+    expect(validateIotForm({ pingIntervalMs: '999', pingTimeoutMs: '100' })).toBe(
+      `Ping interval must be at least ${MIN_PING_INTERVAL_MS}ms`,
+    )
+  })
+
+  it('returns error when ping interval is NaN', () => {
+    expect(validateIotForm({ pingIntervalMs: 'abc', pingTimeoutMs: '100' })).toBe(
+      `Ping interval must be at least ${MIN_PING_INTERVAL_MS}ms`,
+    )
+  })
+
+  it('returns error when ping interval exceeds maximum', () => {
+    expect(validateIotForm({ pingIntervalMs: '3600001', pingTimeoutMs: '100' })).toBe(
+      `Ping interval must be at most ${MAX_PING_INTERVAL_MS}ms (1 hour)`,
+    )
+  })
+
+  it('returns error when ping timeout is below minimum', () => {
+    expect(validateIotForm({ pingIntervalMs: '10000', pingTimeoutMs: '99' })).toBe(
+      `Ping timeout must be at least ${MIN_PING_TIMEOUT_MS}ms`,
+    )
+  })
+
+  it('returns error when ping timeout is NaN', () => {
+    expect(validateIotForm({ pingIntervalMs: '10000', pingTimeoutMs: 'xyz' })).toBe(
+      `Ping timeout must be at least ${MIN_PING_TIMEOUT_MS}ms`,
+    )
+  })
+
+  it('returns error when ping timeout exceeds maximum', () => {
+    expect(validateIotForm({ pingIntervalMs: '120000', pingTimeoutMs: '60001' })).toBe(
+      `Ping timeout must be at most ${MAX_PING_TIMEOUT_MS}ms (1 minute)`,
+    )
+  })
+
+  it('returns error when timeout is not less than interval', () => {
+    expect(validateIotForm({ pingIntervalMs: '5000', pingTimeoutMs: '5000' })).toBe(
+      'Ping timeout must be less than ping interval',
+    )
+  })
+
+  it('returns error when timeout exceeds interval', () => {
+    expect(validateIotForm({ pingIntervalMs: '5000', pingTimeoutMs: '10000' })).toBe(
+      'Ping timeout must be less than ping interval',
+    )
+  })
+})
+
+describe('isIotRawFormData', () => {
+  describe('valid data', () => {
+    it('returns true for valid payload', () => {
+      expect(isIotRawFormData({ pingIntervalMs: '30000', pingTimeoutMs: '3000' })).toBe(true)
+    })
+
+    it('returns true for payload with extra fields', () => {
+      expect(isIotRawFormData({ pingIntervalMs: '30000', pingTimeoutMs: '3000', extra: 'field' })).toBe(true)
+    })
+  })
+
+  describe('primitives and nullish', () => {
+    it('returns false for null', () => {
+      expect(isIotRawFormData(null)).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+      expect(isIotRawFormData(undefined)).toBe(false)
+    })
+
+    it('returns false for string', () => {
+      expect(isIotRawFormData('hello')).toBe(false)
+    })
+
+    it('returns false for number', () => {
+      expect(isIotRawFormData(42)).toBe(false)
+    })
+  })
+
+  describe('missing or wrong types', () => {
+    it('returns false when pingIntervalMs is missing', () => {
+      expect(isIotRawFormData({ pingTimeoutMs: '3000' })).toBe(false)
+    })
+
+    it('returns false when pingTimeoutMs is missing', () => {
+      expect(isIotRawFormData({ pingIntervalMs: '30000' })).toBe(false)
+    })
+
+    it('returns false when pingIntervalMs is not a string', () => {
+      expect(isIotRawFormData({ pingIntervalMs: 30000, pingTimeoutMs: '3000' })).toBe(false)
+    })
+
+    it('returns false when pingTimeoutMs is not a string', () => {
+      expect(isIotRawFormData({ pingIntervalMs: '30000', pingTimeoutMs: 3000 })).toBe(false)
+    })
+  })
+
+  describe('validation failures', () => {
+    it('returns false when interval is below minimum', () => {
+      expect(isIotRawFormData({ pingIntervalMs: '999', pingTimeoutMs: '100' })).toBe(false)
+    })
+
+    it('returns false when timeout exceeds interval', () => {
+      expect(isIotRawFormData({ pingIntervalMs: '5000', pingTimeoutMs: '5000' })).toBe(false)
+    })
+  })
+})

--- a/frontend/src/pages/admin/iot-settings.tsx
+++ b/frontend/src/pages/admin/iot-settings.tsx
@@ -106,9 +106,11 @@ const IotSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
           <Form<IotRawFormData>
             validate={(data): data is IotRawFormData => {
               const isValid = isIotRawFormData(data)
-              if (!isValid && typeof data === 'object' && data !== null) {
-                validationErrorObservable.setValue(validateIotForm(data as Record<string, unknown>))
-              }
+              validationErrorObservable.setValue(
+                isValid || typeof data !== 'object' || data === null
+                  ? null
+                  : validateIotForm(data as Record<string, unknown>),
+              )
               return isValid
             }}
             onSubmit={(data) => void handleSubmit(data)}

--- a/frontend/src/pages/admin/iot-settings.tsx
+++ b/frontend/src/pages/admin/iot-settings.tsx
@@ -8,12 +8,46 @@ import { ConfigService } from '../../services/config-service.js'
 
 type IotFormData = IotConfig['value']
 
-const MIN_PING_INTERVAL_MS = 1000
-const MAX_PING_INTERVAL_MS = 3600000
-const MIN_PING_TIMEOUT_MS = 100
-const MAX_PING_TIMEOUT_MS = 60000
+export const MIN_PING_INTERVAL_MS = 1000
+export const MAX_PING_INTERVAL_MS = 3600000
+export const MIN_PING_TIMEOUT_MS = 100
+export const MAX_PING_TIMEOUT_MS = 60000
 const DEFAULT_PING_INTERVAL_MS = 30000
 const DEFAULT_PING_TIMEOUT_MS = 3000
+
+export type IotRawFormData = {
+  pingIntervalMs: string
+  pingTimeoutMs: string
+}
+
+export const validateIotForm = (data: Record<string, unknown>): string | null => {
+  const pingIntervalMs = Number(data.pingIntervalMs)
+  const pingTimeoutMs = Number(data.pingTimeoutMs)
+
+  if (isNaN(pingIntervalMs) || pingIntervalMs < MIN_PING_INTERVAL_MS) {
+    return `Ping interval must be at least ${MIN_PING_INTERVAL_MS}ms`
+  }
+  if (pingIntervalMs > MAX_PING_INTERVAL_MS) {
+    return `Ping interval must be at most ${MAX_PING_INTERVAL_MS}ms (1 hour)`
+  }
+  if (isNaN(pingTimeoutMs) || pingTimeoutMs < MIN_PING_TIMEOUT_MS) {
+    return `Ping timeout must be at least ${MIN_PING_TIMEOUT_MS}ms`
+  }
+  if (pingTimeoutMs > MAX_PING_TIMEOUT_MS) {
+    return `Ping timeout must be at most ${MAX_PING_TIMEOUT_MS}ms (1 minute)`
+  }
+  if (pingTimeoutMs >= pingIntervalMs) {
+    return 'Ping timeout must be less than ping interval'
+  }
+  return null
+}
+
+export const isIotRawFormData = (data: unknown): data is IotRawFormData => {
+  if (typeof data !== 'object' || data === null) return false
+  const d = data as Record<string, unknown>
+  if (typeof d.pingIntervalMs !== 'string' || typeof d.pingTimeoutMs !== 'string') return false
+  return validateIotForm(d) === null
+}
 
 const IotSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
   shadowDomName: 'iot-settings-content',
@@ -27,34 +61,7 @@ const IotSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
     const validationErrorObservable = useDisposable('validationError', () => new ObservableValue<string | null>(null))
     const [validationError] = useObservable('validationErrorValue', validationErrorObservable)
 
-    const validateForm = (formData: Record<string, unknown>): string | null => {
-      const pingIntervalMs = Number(formData.pingIntervalMs)
-      const pingTimeoutMs = Number(formData.pingTimeoutMs)
-
-      if (isNaN(pingIntervalMs) || pingIntervalMs < MIN_PING_INTERVAL_MS) {
-        return `Ping interval must be at least ${MIN_PING_INTERVAL_MS}ms`
-      }
-      if (pingIntervalMs > MAX_PING_INTERVAL_MS) {
-        return `Ping interval must be at most ${MAX_PING_INTERVAL_MS}ms (1 hour)`
-      }
-      if (isNaN(pingTimeoutMs) || pingTimeoutMs < MIN_PING_TIMEOUT_MS) {
-        return `Ping timeout must be at least ${MIN_PING_TIMEOUT_MS}ms`
-      }
-      if (pingTimeoutMs > MAX_PING_TIMEOUT_MS) {
-        return `Ping timeout must be at most ${MAX_PING_TIMEOUT_MS}ms (1 minute)`
-      }
-      if (pingTimeoutMs >= pingIntervalMs) {
-        return 'Ping timeout must be less than ping interval'
-      }
-      return null
-    }
-
-    const handleSubmit = async (formData: Record<string, unknown>) => {
-      const error = validateForm(formData)
-      if (error) {
-        validationErrorObservable.setValue(error)
-        return
-      }
+    const handleSubmit = async (formData: IotRawFormData) => {
       validationErrorObservable.setValue(null)
 
       const data: IotFormData = {
@@ -96,11 +103,13 @@ const IotSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
         </p>
 
         <Paper elevation={1} style={{ padding: '24px' }}>
-          <Form<Record<string, unknown>>
-            validate={(data): data is Record<string, unknown> => {
-              const error = validateForm(data as Record<string, unknown>)
-              validationErrorObservable.setValue(error)
-              return error === null
+          <Form<IotRawFormData>
+            validate={(data): data is IotRawFormData => {
+              const isValid = isIotRawFormData(data)
+              if (!isValid && typeof data === 'object' && data !== null) {
+                validationErrorObservable.setValue(validateIotForm(data as Record<string, unknown>))
+              }
+              return isValid
             }}
             onSubmit={(data) => void handleSubmit(data)}
           >

--- a/frontend/src/pages/admin/omdb-settings.spec.ts
+++ b/frontend/src/pages/admin/omdb-settings.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { isOmdbRawFormData } from './omdb-settings.js'
+
+describe('isOmdbRawFormData', () => {
+  describe('valid data', () => {
+    it('returns true for valid payload with all fields', () => {
+      expect(
+        isOmdbRawFormData({
+          apiKey: 'test-key',
+          trySearchMovieFromTitle: 'on',
+          autoDownloadMetadata: 'on',
+        }),
+      ).toBe(true)
+    })
+
+    it('returns true for minimal valid payload', () => {
+      expect(isOmdbRawFormData({ apiKey: 'key' })).toBe(true)
+    })
+
+    it('returns true for empty apiKey string', () => {
+      expect(isOmdbRawFormData({ apiKey: '' })).toBe(true)
+    })
+
+    it('returns true for payload with extra fields', () => {
+      expect(isOmdbRawFormData({ apiKey: 'key', extra: 'field' })).toBe(true)
+    })
+  })
+
+  describe('primitives and nullish', () => {
+    it('returns false for null', () => {
+      expect(isOmdbRawFormData(null)).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+      expect(isOmdbRawFormData(undefined)).toBe(false)
+    })
+
+    it('returns false for string', () => {
+      expect(isOmdbRawFormData('hello')).toBe(false)
+    })
+
+    it('returns false for number', () => {
+      expect(isOmdbRawFormData(42)).toBe(false)
+    })
+  })
+
+  describe('missing or wrong types', () => {
+    it('returns false when apiKey is missing', () => {
+      expect(isOmdbRawFormData({ trySearchMovieFromTitle: 'on' })).toBe(false)
+    })
+
+    it('returns false when apiKey is not a string', () => {
+      expect(isOmdbRawFormData({ apiKey: 123 })).toBe(false)
+    })
+
+    it('returns false when apiKey is null', () => {
+      expect(isOmdbRawFormData({ apiKey: null })).toBe(false)
+    })
+
+    it('returns false for empty object', () => {
+      expect(isOmdbRawFormData({})).toBe(false)
+    })
+  })
+})

--- a/frontend/src/pages/admin/omdb-settings.tsx
+++ b/frontend/src/pages/admin/omdb-settings.tsx
@@ -8,6 +8,18 @@ import { ConfigService } from '../../services/config-service.js'
 
 type OmdbFormData = OmdbConfig['value']
 
+export type OmdbRawFormData = {
+  apiKey: string
+  trySearchMovieFromTitle?: string
+  autoDownloadMetadata?: string
+}
+
+export const isOmdbRawFormData = (data: unknown): data is OmdbRawFormData => {
+  if (typeof data !== 'object' || data === null) return false
+  const d = data as Record<string, unknown>
+  return typeof d.apiKey === 'string'
+}
+
 const OmdbSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
   shadowDomName: 'omdb-settings-content',
   css: {
@@ -66,9 +78,9 @@ const OmdbSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
       setApiKeyVisible(!isApiKeyVisible)
     }
 
-    const handleSubmit = async (formData: Record<string, unknown>) => {
+    const handleSubmit = async (formData: OmdbRawFormData) => {
       const data: OmdbFormData = {
-        apiKey: formData.apiKey as string,
+        apiKey: formData.apiKey,
         trySearchMovieFromTitle: formData.trySearchMovieFromTitle === 'on',
         autoDownloadMetadata: formData.autoDownloadMetadata === 'on',
       }
@@ -102,12 +114,7 @@ const OmdbSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
         <p className="page-description">Configure the OMDB API integration for fetching movie and series metadata.</p>
 
         <Paper elevation={1} style={{ padding: '24px' }}>
-          <Form<Record<string, unknown>>
-            validate={(data): data is Record<string, unknown> => {
-              return typeof (data as Record<string, unknown>).apiKey === 'string'
-            }}
-            onSubmit={(data) => void handleSubmit(data)}
-          >
+          <Form<OmdbRawFormData> validate={isOmdbRawFormData} onSubmit={(data) => void handleSubmit(data)}>
             <div className="form-field">
               <div className="api-key-row">
                 <Input

--- a/frontend/src/pages/admin/streaming-settings.spec.ts
+++ b/frontend/src/pages/admin/streaming-settings.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { isStreamingRawFormData } from './streaming-settings.js'
+
+describe('isStreamingRawFormData', () => {
+  describe('valid data', () => {
+    it('returns true for valid payload with all fields', () => {
+      expect(
+        isStreamingRawFormData({
+          preset: 'medium',
+          threads: '4',
+          autoExtractSubtitles: 'on',
+          fullSyncOnStartup: 'on',
+          watchFiles: 'all',
+        }),
+      ).toBe(true)
+    })
+
+    it('returns true for minimal valid payload', () => {
+      expect(isStreamingRawFormData({ threads: '1' })).toBe(true)
+    })
+
+    it('returns true for threads at upper bound', () => {
+      expect(isStreamingRawFormData({ threads: '64' })).toBe(true)
+    })
+
+    it('returns true for payload with extra fields', () => {
+      expect(isStreamingRawFormData({ preset: 'fast', threads: '8', extra: 'field' })).toBe(true)
+    })
+  })
+
+  describe('primitives and nullish', () => {
+    it('returns false for null', () => {
+      expect(isStreamingRawFormData(null)).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+      expect(isStreamingRawFormData(undefined)).toBe(false)
+    })
+
+    it('returns false for string', () => {
+      expect(isStreamingRawFormData('hello')).toBe(false)
+    })
+
+    it('returns false for number', () => {
+      expect(isStreamingRawFormData(42)).toBe(false)
+    })
+  })
+
+  describe('missing or invalid threads', () => {
+    it('returns false when threads is missing', () => {
+      expect(isStreamingRawFormData({ preset: 'medium' })).toBe(false)
+    })
+
+    it('returns false when threads is not a string', () => {
+      expect(isStreamingRawFormData({ preset: 'medium', threads: 4 })).toBe(false)
+    })
+
+    it('returns false when threads is NaN', () => {
+      expect(isStreamingRawFormData({ preset: 'medium', threads: 'abc' })).toBe(false)
+    })
+
+    it('returns false when threads is below 1', () => {
+      expect(isStreamingRawFormData({ preset: 'medium', threads: '0' })).toBe(false)
+    })
+
+    it('returns false when threads is above 64', () => {
+      expect(isStreamingRawFormData({ preset: 'medium', threads: '65' })).toBe(false)
+    })
+
+    it('returns true when threads is exactly 1', () => {
+      expect(isStreamingRawFormData({ threads: '1' })).toBe(true)
+    })
+  })
+})

--- a/frontend/src/pages/admin/streaming-settings.tsx
+++ b/frontend/src/pages/admin/streaming-settings.tsx
@@ -8,6 +8,21 @@ import { ConfigService } from '../../services/config-service.js'
 
 type StreamingFormData = MoviesConfig['value']
 
+export type StreamingRawFormData = {
+  autoExtractSubtitles?: string
+  fullSyncOnStartup?: string
+  preset: string
+  threads: string
+  watchFiles?: string
+}
+
+export const isStreamingRawFormData = (data: unknown): data is StreamingRawFormData => {
+  if (typeof data !== 'object' || data === null) return false
+  const d = data as Record<string, unknown>
+  const threads = Number(d.threads)
+  return typeof d.threads === 'string' && !isNaN(threads) && threads >= 1 && threads <= 64
+}
+
 const PRESET_OPTIONS = [
   { value: 'ultrafast', label: 'Ultra Fast' },
   { value: 'superfast', label: 'Super Fast' },
@@ -92,7 +107,7 @@ const StreamingSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
     const isLoadingObservable = useDisposable('isLoading', () => new ObservableValue(false))
     const [isLoading] = useObservable('isLoadingValue', isLoadingObservable)
 
-    const handleSubmit = async (formData: Record<string, unknown>) => {
+    const handleSubmit = async (formData: StreamingRawFormData) => {
       const data: StreamingFormData = {
         autoExtractSubtitles: formData.autoExtractSubtitles === 'on',
         fullSyncOnStartup: formData.fullSyncOnStartup === 'on',
@@ -136,14 +151,7 @@ const StreamingSettingsContent = Shade<{ data: CacheWithValue<Config> }>({
         <p className="page-description">Configure media transcoding and file watching settings.</p>
 
         <Paper elevation={1} style={{ padding: '24px' }}>
-          <Form<Record<string, unknown>>
-            validate={(data): data is Record<string, unknown> => {
-              const formData = data as Record<string, unknown>
-              const threads = Number(formData.threads)
-              return !isNaN(threads) && threads >= 1 && threads <= 64
-            }}
-            onSubmit={(data) => void handleSubmit(data)}
-          >
+          <Form<StreamingRawFormData> validate={isStreamingRawFormData} onSubmit={(data) => void handleSubmit(data)}>
             <h3 className="section-title">File Discovery</h3>
 
             <div className="form-field">

--- a/frontend/src/pages/ai/ai-chat-input.spec.ts
+++ b/frontend/src/pages/ai/ai-chat-input.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { isAiMessagePayload } from './ai-chat-input.js'
+
+describe('isAiMessagePayload', () => {
+  describe('valid data', () => {
+    it('returns true for valid payload', () => {
+      expect(isAiMessagePayload({ message: 'Hello' })).toBe(true)
+    })
+
+    it('returns true for payload with extra fields', () => {
+      expect(isAiMessagePayload({ message: 'Hello', extra: 'field' })).toBe(true)
+    })
+  })
+
+  describe('primitives and nullish', () => {
+    it('returns false for null', () => {
+      expect(isAiMessagePayload(null)).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+      expect(isAiMessagePayload(undefined)).toBe(false)
+    })
+
+    it('returns false for string', () => {
+      expect(isAiMessagePayload('hello')).toBe(false)
+    })
+
+    it('returns false for number', () => {
+      expect(isAiMessagePayload(42)).toBe(false)
+    })
+
+    it('returns false for boolean', () => {
+      expect(isAiMessagePayload(true)).toBe(false)
+    })
+  })
+
+  describe('missing fields', () => {
+    it('returns false when message is missing', () => {
+      expect(isAiMessagePayload({})).toBe(false)
+    })
+  })
+
+  describe('wrong types', () => {
+    it('returns false when message is not a string', () => {
+      expect(isAiMessagePayload({ message: 123 })).toBe(false)
+    })
+
+    it('returns false when message is null', () => {
+      expect(isAiMessagePayload({ message: null })).toBe(false)
+    })
+
+    it('returns false when message is undefined', () => {
+      expect(isAiMessagePayload({ message: undefined })).toBe(false)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns false when message is whitespace-only', () => {
+      expect(isAiMessagePayload({ message: '   ' })).toBe(false)
+    })
+
+    it('returns true when message has leading/trailing spaces', () => {
+      expect(isAiMessagePayload({ message: '  hello  ' })).toBe(true)
+    })
+  })
+})

--- a/frontend/src/pages/ai/ai-chat-input.tsx
+++ b/frontend/src/pages/ai/ai-chat-input.tsx
@@ -4,6 +4,16 @@ import { SessionService } from '../../services/session.js'
 import { AiChatMessageService } from './ai-chat-message-service.js'
 import { AiChatService } from './ai-chat-service.js'
 
+export type AiMessagePayload = {
+  message: string
+}
+
+export const isAiMessagePayload = (data: unknown): data is AiMessagePayload => {
+  if (typeof data !== 'object' || data === null) return false
+  const d = data as Record<string, unknown>
+  return typeof d.message === 'string' && d.message.trim() !== ''
+}
+
 export const AiChatInput = Shade<{ selectedChatId: string }>({
   shadowDomName: 'pi-rat-ai-chat-input',
   style: {
@@ -27,7 +37,7 @@ export const AiChatInput = Shade<{ selectedChatId: string }>({
     )
 
     return (
-      <Form<{ message: string }>
+      <Form<AiMessagePayload>
         ref={formRef}
         onSubmit={({ message }) => {
           void aiChatMessageService
@@ -44,15 +54,7 @@ export const AiChatInput = Shade<{ selectedChatId: string }>({
               formRef.current?.reset()
             })
         }}
-        validate={(formData): formData is { message: string } => {
-          return (
-            typeof formData === 'object' &&
-            formData !== null &&
-            'message' in formData &&
-            typeof (formData as { message?: unknown }).message === 'string' &&
-            (formData as { message: string }).message.trim() !== ''
-          )
-        }}
+        validate={isAiMessagePayload}
         style={{ display: 'flex', flexDirection: 'row', width: '100%' }}
       >
         <Input

--- a/frontend/src/pages/ai/create-ai-chat-button.spec.ts
+++ b/frontend/src/pages/ai/create-ai-chat-button.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { isCreateAiChatPayload } from './create-ai-chat-button.js'
+
+describe('isCreateAiChatPayload', () => {
+  describe('valid data', () => {
+    it('returns true for valid payload with required fields only', () => {
+      expect(isCreateAiChatPayload({ name: 'My Chat', model: 'gpt-4' })).toBe(true)
+    })
+
+    it('returns true for valid payload with description', () => {
+      expect(isCreateAiChatPayload({ name: 'My Chat', model: 'gpt-4', description: 'A chat' })).toBe(true)
+    })
+
+    it('returns true for payload with extra fields', () => {
+      expect(isCreateAiChatPayload({ name: 'Chat', model: 'gpt-4', extra: 'field' })).toBe(true)
+    })
+  })
+
+  describe('primitives and nullish', () => {
+    it('returns false for null', () => {
+      expect(isCreateAiChatPayload(null)).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+      expect(isCreateAiChatPayload(undefined)).toBe(false)
+    })
+
+    it('returns false for string', () => {
+      expect(isCreateAiChatPayload('hello')).toBe(false)
+    })
+
+    it('returns false for number', () => {
+      expect(isCreateAiChatPayload(42)).toBe(false)
+    })
+  })
+
+  describe('missing fields', () => {
+    it('returns false when name is missing', () => {
+      expect(isCreateAiChatPayload({ model: 'gpt-4' })).toBe(false)
+    })
+
+    it('returns false when model is missing', () => {
+      expect(isCreateAiChatPayload({ name: 'Chat' })).toBe(false)
+    })
+
+    it('returns false when all required fields are missing', () => {
+      expect(isCreateAiChatPayload({})).toBe(false)
+    })
+  })
+
+  describe('wrong types', () => {
+    it('returns false when name is not a string', () => {
+      expect(isCreateAiChatPayload({ name: 123, model: 'gpt-4' })).toBe(false)
+    })
+
+    it('returns false when model is not a string', () => {
+      expect(isCreateAiChatPayload({ name: 'Chat', model: 42 })).toBe(false)
+    })
+
+    it('returns false when description is not a string or undefined', () => {
+      expect(isCreateAiChatPayload({ name: 'Chat', model: 'gpt-4', description: 123 })).toBe(false)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns false when name is whitespace-only', () => {
+      expect(isCreateAiChatPayload({ name: '   ', model: 'gpt-4' })).toBe(false)
+    })
+
+    it('returns false when model is whitespace-only', () => {
+      expect(isCreateAiChatPayload({ name: 'Chat', model: '   ' })).toBe(false)
+    })
+
+    it('returns true when description is undefined', () => {
+      expect(isCreateAiChatPayload({ name: 'Chat', model: 'gpt-4', description: undefined })).toBe(true)
+    })
+
+    it('returns true when description is missing', () => {
+      expect(isCreateAiChatPayload({ name: 'Chat', model: 'gpt-4' })).toBe(true)
+    })
+
+    it('returns true when description is empty string', () => {
+      expect(isCreateAiChatPayload({ name: 'Chat', model: 'gpt-4', description: '' })).toBe(true)
+    })
+  })
+})

--- a/frontend/src/pages/ai/create-ai-chat-button.tsx
+++ b/frontend/src/pages/ai/create-ai-chat-button.tsx
@@ -6,6 +6,20 @@ import { SessionService } from '../../services/session.js'
 import { AiChatService } from './ai-chat-service.js'
 import { AiModelSelector } from './ai-model-selector.js'
 
+export type CreateAiChatPayload = Pick<AiChat, 'name' | 'description' | 'model'>
+
+export const isCreateAiChatPayload = (data: unknown): data is CreateAiChatPayload => {
+  if (typeof data !== 'object' || data === null) return false
+  const d = data as Record<string, unknown>
+  return (
+    typeof d.name === 'string' &&
+    d.name.trim() !== '' &&
+    (typeof d.description === 'string' || d.description === undefined) &&
+    typeof d.model === 'string' &&
+    d.model.trim() !== ''
+  )
+}
+
 export const CreateAiChatButton = Shade({
   shadowDomName: 'pi-rat-create-ai-chat-button',
   render: ({ injector, useState }) => {
@@ -44,7 +58,7 @@ export const CreateAiChatButton = Shade({
         >
           <Paper onclick={(ev) => ev.stopPropagation()}>
             <h2>Create New AI Chat</h2>
-            <Form<Pick<AiChat, 'name' | 'description' | 'model'>>
+            <Form<CreateAiChatPayload>
               onSubmit={(chat) => {
                 aiChatService
                   .createChat({
@@ -80,21 +94,7 @@ export const CreateAiChatButton = Shade({
                     })
                   })
               }}
-              validate={(formData): formData is Pick<AiChat, 'name' | 'description' | 'model'> => {
-                return (
-                  typeof formData === 'object' &&
-                  formData !== null &&
-                  'name' in formData &&
-                  typeof (formData as AiChat).name === 'string' &&
-                  (formData as AiChat).name.trim() !== '' &&
-                  'description' in formData &&
-                  (typeof (formData as AiChat).description === 'string' ||
-                    (formData as AiChat).description === undefined) &&
-                  'model' in formData &&
-                  typeof (formData as AiChat).model === 'string' &&
-                  (formData as AiChat).model.trim() !== ''
-                )
-              }}
+              validate={isCreateAiChatPayload}
             >
               Select model:
               <AiModelSelector />

--- a/frontend/src/pages/chat/add-chat-button.spec.ts
+++ b/frontend/src/pages/chat/add-chat-button.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { isAddChatPayload } from './add-chat-button.js'
+
+describe('isAddChatPayload', () => {
+  it('returns true for valid payload with name and description', () => {
+    expect(isAddChatPayload({ name: 'Chat', description: 'My chat' })).toBe(true)
+  })
+
+  it('returns true for valid payload with name only (optional description)', () => {
+    expect(isAddChatPayload({ name: 'Chat' })).toBe(true)
+  })
+
+  it('returns true for payload with extra fields', () => {
+    expect(isAddChatPayload({ name: 'Chat', description: 'Desc', extra: 123 })).toBe(true)
+  })
+
+  it('returns false for null', () => {
+    expect(isAddChatPayload(null)).toBe(false)
+  })
+
+  it('returns false for undefined', () => {
+    expect(isAddChatPayload(undefined)).toBe(false)
+  })
+
+  it('returns false for non-object types', () => {
+    expect(isAddChatPayload('string')).toBe(false)
+    expect(isAddChatPayload(42)).toBe(false)
+    expect(isAddChatPayload(true)).toBe(false)
+    expect(isAddChatPayload([])).toBe(false)
+  })
+
+  it('returns false when name is missing', () => {
+    expect(isAddChatPayload({ description: 'Desc' })).toBe(false)
+  })
+
+  it('returns false when name is empty string', () => {
+    expect(isAddChatPayload({ name: '' })).toBe(false)
+  })
+
+  it('returns false when name has wrong type', () => {
+    expect(isAddChatPayload({ name: 123 })).toBe(false)
+    expect(isAddChatPayload({ name: null })).toBe(false)
+  })
+
+  it('returns false when description has wrong type', () => {
+    expect(isAddChatPayload({ name: 'Chat', description: 123 })).toBe(false)
+  })
+
+  it('returns true when description is empty string', () => {
+    expect(isAddChatPayload({ name: 'Chat', description: '' })).toBe(true)
+  })
+})

--- a/frontend/src/pages/chat/add-chat-button.tsx
+++ b/frontend/src/pages/chat/add-chat-button.tsx
@@ -1,8 +1,22 @@
 import { createComponent, Shade } from '@furystack/shades'
 import { Button, Form, Input, Modal, Paper } from '@furystack/shades-common-components'
-import type { Chat } from 'common'
 import { SessionService } from '../../services/session.js'
 import { ChatService } from './chat-service.js'
+
+export type AddChatPayload = {
+  name: string
+  description?: string
+}
+
+export const isAddChatPayload = (data: unknown): data is AddChatPayload => {
+  if (typeof data !== 'object' || data === null) return false
+  const d = data as Record<string, unknown>
+  return (
+    typeof d.name === 'string' &&
+    d.name.length > 0 &&
+    (d.description === undefined || typeof d.description === 'string')
+  )
+}
 
 export const AddChatButton = Shade({
   shadowDomName: 'shade-app-chat-add-chat-button',
@@ -35,11 +49,12 @@ export const AddChatButton = Shade({
         >
           <Paper onclick={(ev) => ev.stopPropagation()}>
             <h2>Add New Chat</h2>
-            <Form<Chat>
-              onSubmit={(chat: Chat) => {
+            <Form<AddChatPayload>
+              validate={isAddChatPayload}
+              onSubmit={(chatData) => {
                 chats
                   .addChat({
-                    ...chat,
+                    ...chatData,
                     id: crypto.randomUUID(),
                     participants: [],
                     createdAt: new Date(),
@@ -51,9 +66,6 @@ export const AddChatButton = Shade({
                   .catch((error) => {
                     console.error('Error adding chat:', error)
                   })
-              }}
-              validate={(_formData): _formData is Chat => {
-                return true
               }}
             >
               <Input name="name" labelTitle="Chat Name" placeholder="Enter chat name" required />

--- a/frontend/src/pages/chat/invite-button.spec.ts
+++ b/frontend/src/pages/chat/invite-button.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { isInvitePayload } from './invite-button.js'
+
+describe('isInvitePayload', () => {
+  it('returns true for valid payload', () => {
+    expect(isInvitePayload({ userName: 'alice', message: 'Join us!' })).toBe(true)
+  })
+
+  it('returns true for payload with extra fields', () => {
+    expect(isInvitePayload({ userName: 'alice', message: 'Hi', extra: 123 })).toBe(true)
+  })
+
+  it('returns true when message is empty (trimmed length <= 500)', () => {
+    expect(isInvitePayload({ userName: 'alice', message: '' })).toBe(true)
+  })
+
+  it('returns true when message is at max length (500 chars)', () => {
+    expect(isInvitePayload({ userName: 'alice', message: 'x'.repeat(500) })).toBe(true)
+  })
+
+  it('returns false for null', () => {
+    expect(isInvitePayload(null)).toBe(false)
+  })
+
+  it('returns false for undefined', () => {
+    expect(isInvitePayload(undefined)).toBe(false)
+  })
+
+  it('returns false for non-object types', () => {
+    expect(isInvitePayload('string')).toBe(false)
+    expect(isInvitePayload(42)).toBe(false)
+    expect(isInvitePayload(true)).toBe(false)
+    expect(isInvitePayload([])).toBe(false)
+  })
+
+  it('returns false when userName is missing', () => {
+    expect(isInvitePayload({ message: 'Hi' })).toBe(false)
+  })
+
+  it('returns false when message is missing', () => {
+    expect(isInvitePayload({ userName: 'alice' })).toBe(false)
+  })
+
+  it('returns false when userName is empty string', () => {
+    expect(isInvitePayload({ userName: '', message: 'Hi' })).toBe(false)
+  })
+
+  it('returns false when userName is whitespace-only', () => {
+    expect(isInvitePayload({ userName: '   ', message: 'Hi' })).toBe(false)
+  })
+
+  it('returns false when message exceeds 500 chars after trim', () => {
+    expect(isInvitePayload({ userName: 'alice', message: 'x'.repeat(501) })).toBe(false)
+  })
+
+  it('returns false when userName has wrong type', () => {
+    expect(isInvitePayload({ userName: 123, message: 'Hi' })).toBe(false)
+  })
+
+  it('returns false when message has wrong type', () => {
+    expect(isInvitePayload({ userName: 'alice', message: 123 })).toBe(false)
+  })
+})

--- a/frontend/src/pages/chat/invite-button.tsx
+++ b/frontend/src/pages/chat/invite-button.tsx
@@ -5,6 +5,22 @@ import { ErrorDisplay } from '../../components/error-display.js'
 import { SessionService } from '../../services/session.js'
 import { ChatInvitationService } from './chat-intivation-service.js'
 
+export type InvitePayload = {
+  userName: string
+  message: string
+}
+
+export const isInvitePayload = (data: unknown): data is InvitePayload => {
+  if (typeof data !== 'object' || data === null) return false
+  const d = data as Record<string, unknown>
+  return (
+    typeof d.userName === 'string' &&
+    d.userName.trim().length > 0 &&
+    typeof d.message === 'string' &&
+    d.message.trim().length <= 500
+  )
+}
+
 export const InviteButton = Shade<{ chat: Chat }>({
   shadowDomName: 'shade-app-invite-button',
   render: ({ useState, props, injector }) => {
@@ -36,7 +52,7 @@ export const InviteButton = Shade<{ chat: Chat }>({
           isVisible={isModalOpen}
         >
           <Paper onclick={(ev) => ev.stopPropagation()}>
-            <Form<{ userName: string; message: string }>
+            <Form<InvitePayload>
               style={{
                 zIndex: '9000',
                 display: 'flex',
@@ -70,18 +86,7 @@ export const InviteButton = Shade<{ chat: Chat }>({
                     })
                   })
               }}
-              validate={(formData): formData is { userName: string; message: string } => {
-                return (
-                  typeof formData === 'object' &&
-                  formData !== null &&
-                  'userName' in formData &&
-                  typeof (formData as { userName: unknown }).userName === 'string' &&
-                  (formData as { userName: string }).userName.trim().length > 0 &&
-                  'message' in formData &&
-                  typeof (formData as { message: unknown }).message === 'string' &&
-                  (formData as { message: string }).message.trim().length <= 500
-                )
-              }}
+              validate={isInvitePayload}
             >
               <h2>Invite</h2>
               <div>

--- a/frontend/src/pages/chat/message-input.spec.ts
+++ b/frontend/src/pages/chat/message-input.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { isChatMessagePayload } from './message-input.js'
+
+describe('isChatMessagePayload', () => {
+  it('returns true for valid payload', () => {
+    expect(isChatMessagePayload({ content: 'Hello' })).toBe(true)
+  })
+
+  it('returns true for payload with extra fields', () => {
+    expect(isChatMessagePayload({ content: 'Hello', extra: 123 })).toBe(true)
+  })
+
+  it('returns false for null', () => {
+    expect(isChatMessagePayload(null)).toBe(false)
+  })
+
+  it('returns false for undefined', () => {
+    expect(isChatMessagePayload(undefined)).toBe(false)
+  })
+
+  it('returns false for non-object types', () => {
+    expect(isChatMessagePayload('string')).toBe(false)
+    expect(isChatMessagePayload(42)).toBe(false)
+    expect(isChatMessagePayload(true)).toBe(false)
+    expect(isChatMessagePayload([])).toBe(false)
+  })
+
+  it('returns false when content is missing', () => {
+    expect(isChatMessagePayload({})).toBe(false)
+  })
+
+  it('returns false when content is empty string', () => {
+    expect(isChatMessagePayload({ content: '' })).toBe(false)
+  })
+
+  it('returns false when content is whitespace-only', () => {
+    expect(isChatMessagePayload({ content: '   ' })).toBe(false)
+  })
+
+  it('returns false when content has wrong type', () => {
+    expect(isChatMessagePayload({ content: 123 })).toBe(false)
+    expect(isChatMessagePayload({ content: null })).toBe(false)
+  })
+})

--- a/frontend/src/pages/chat/message-input.tsx
+++ b/frontend/src/pages/chat/message-input.tsx
@@ -4,6 +4,16 @@ import type { Chat } from 'common'
 import { SessionService } from '../../services/session.js'
 import { ChatMessageService } from './chat-messages-service.js'
 
+export type ChatMessagePayload = {
+  content: string
+}
+
+export const isChatMessagePayload = (data: unknown): data is ChatMessagePayload => {
+  if (typeof data !== 'object' || data === null) return false
+  const d = data as Record<string, unknown>
+  return typeof d.content === 'string' && d.content.trim().length > 0
+}
+
 export const MessageInput = Shade<{ chat: Chat }>({
   shadowDomName: 'shade-app-message-input',
   render: ({ injector, props, useRef }) => {
@@ -13,7 +23,7 @@ export const MessageInput = Shade<{ chat: Chat }>({
     const formRef = useRef<HTMLFormElement>('form')
 
     return (
-      <Form<{ content: string }>
+      <Form<ChatMessagePayload>
         ref={formRef}
         onSubmit={(formData) => {
           void chatService.addChatMessage({
@@ -26,15 +36,7 @@ export const MessageInput = Shade<{ chat: Chat }>({
           })
           formRef.current?.reset()
         }}
-        validate={(formData: unknown): formData is { content: string } => {
-          return (
-            typeof formData === 'object' &&
-            formData !== null &&
-            'content' in formData &&
-            typeof (formData as { content: unknown }).content === 'string' &&
-            (formData as { content: string }).content.trim().length > 0
-          )
-        }}
+        validate={isChatMessagePayload}
         style={{
           display: 'flex',
           flexDirection: 'row',

--- a/frontend/src/pages/file-browser/create-drive-wizard.spec.ts
+++ b/frontend/src/pages/file-browser/create-drive-wizard.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { isAddDrivePayload } from './create-drive-wizard.js'
+
+describe('isAddDrivePayload', () => {
+  describe('valid data', () => {
+    it('returns true for valid payload', () => {
+      expect(isAddDrivePayload({ letter: 'C', physicalPath: '/mnt/drive' })).toBe(true)
+    })
+
+    it('returns true for payload with extra fields', () => {
+      expect(isAddDrivePayload({ letter: 'D', physicalPath: '/mnt/storage', extra: 'field' })).toBe(true)
+    })
+  })
+
+  describe('primitives and nullish', () => {
+    it('returns false for null', () => {
+      expect(isAddDrivePayload(null)).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+      expect(isAddDrivePayload(undefined)).toBe(false)
+    })
+
+    it('returns false for string', () => {
+      expect(isAddDrivePayload('hello')).toBe(false)
+    })
+
+    it('returns false for number', () => {
+      expect(isAddDrivePayload(42)).toBe(false)
+    })
+  })
+
+  describe('missing or invalid fields', () => {
+    it('returns false when letter is missing', () => {
+      expect(isAddDrivePayload({ physicalPath: '/mnt/drive' })).toBe(false)
+    })
+
+    it('returns false when physicalPath is missing', () => {
+      expect(isAddDrivePayload({ letter: 'C' })).toBe(false)
+    })
+
+    it('returns false when letter is empty', () => {
+      expect(isAddDrivePayload({ letter: '', physicalPath: '/mnt/drive' })).toBe(false)
+    })
+
+    it('returns false when physicalPath is empty', () => {
+      expect(isAddDrivePayload({ letter: 'C', physicalPath: '' })).toBe(false)
+    })
+
+    it('returns false when letter is not a string', () => {
+      expect(isAddDrivePayload({ letter: 67, physicalPath: '/mnt/drive' })).toBe(false)
+    })
+
+    it('returns false when physicalPath is not a string', () => {
+      expect(isAddDrivePayload({ letter: 'C', physicalPath: 123 })).toBe(false)
+    })
+
+    it('returns false for empty object', () => {
+      expect(isAddDrivePayload({})).toBe(false)
+    })
+  })
+})

--- a/frontend/src/pages/file-browser/create-drive-wizard.tsx
+++ b/frontend/src/pages/file-browser/create-drive-wizard.tsx
@@ -37,7 +37,7 @@ export const AddDriveStep = Shade<WizardStepProps>({
             })
             injector.getInstance(NotyService).emit('onNotyAdded', {
               type: 'success',
-              body: `Drive '${data.letter}' has been created succesfully`,
+              body: `Drive '${data.letter}' has been created successfully`,
               title: 'Drive created',
             })
           } catch (error) {

--- a/frontend/src/pages/file-browser/create-drive-wizard.tsx
+++ b/frontend/src/pages/file-browser/create-drive-wizard.tsx
@@ -5,6 +5,22 @@ import { WizardStep } from '../../components/wizard-step.js'
 import { DrivesService } from '../../services/drives-service.js'
 import { getErrorMessage } from '../../services/get-error-message.js'
 
+export type AddDrivePayload = {
+  letter: string
+  physicalPath: string
+}
+
+export const isAddDrivePayload = (data: unknown): data is AddDrivePayload => {
+  if (typeof data !== 'object' || data === null) return false
+  const d = data as Record<string, unknown>
+  return (
+    typeof d.letter === 'string' &&
+    d.letter.length > 0 &&
+    typeof d.physicalPath === 'string' &&
+    d.physicalPath.length > 0
+  )
+}
+
 export const AddDriveStep = Shade<WizardStepProps>({
   shadowDomName: 'add-drive-step',
   render: ({ props, injector }) => {
@@ -12,21 +28,16 @@ export const AddDriveStep = Shade<WizardStepProps>({
       <WizardStep
         title="Add Drive"
         {...props}
-        onSubmit={async (ev) => {
-          ev.preventDefault()
-          ev.stopPropagation()
-          const form = ev.target as HTMLFormElement
-          const formData = new FormData(form)
-
-          const values = Object.fromEntries(formData.entries()) as { letter: string; physicalPath: string }
+        validate={isAddDrivePayload}
+        onSubmit={async (data) => {
           try {
             await injector.getInstance(DrivesService).addVolume({
-              letter: values.letter.toString(),
-              physicalPath: values.physicalPath.toString(),
+              letter: data.letter,
+              physicalPath: data.physicalPath,
             })
             injector.getInstance(NotyService).emit('onNotyAdded', {
               type: 'success',
-              body: `Drive '${values.letter.toString()}' has been created succesfully`,
+              body: `Drive '${data.letter}' has been created succesfully`,
               title: 'Drive created',
             })
           } catch (error) {

--- a/frontend/src/pages/login.spec.ts
+++ b/frontend/src/pages/login.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { isLoginPayload } from './login.js'
+
+describe('isLoginPayload', () => {
+  describe('valid data', () => {
+    it('returns true for valid payload', () => {
+      expect(isLoginPayload({ userName: 'user@test.com', password: 'secret' })).toBe(true)
+    })
+
+    it('returns true for payload with extra fields', () => {
+      expect(isLoginPayload({ userName: 'user@test.com', password: 'secret', extra: 'field' })).toBe(true)
+    })
+  })
+
+  describe('primitives and nullish', () => {
+    it('returns false for null', () => {
+      expect(isLoginPayload(null)).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+      expect(isLoginPayload(undefined)).toBe(false)
+    })
+
+    it('returns false for string', () => {
+      expect(isLoginPayload('hello')).toBe(false)
+    })
+
+    it('returns false for number', () => {
+      expect(isLoginPayload(42)).toBe(false)
+    })
+  })
+
+  describe('missing fields', () => {
+    it('returns false when userName is missing', () => {
+      expect(isLoginPayload({ password: 'secret' })).toBe(false)
+    })
+
+    it('returns false when password is missing', () => {
+      expect(isLoginPayload({ userName: 'user@test.com' })).toBe(false)
+    })
+
+    it('returns false when all fields are missing', () => {
+      expect(isLoginPayload({})).toBe(false)
+    })
+  })
+
+  describe('empty string fields', () => {
+    it('returns false when userName is empty', () => {
+      expect(isLoginPayload({ userName: '', password: 'secret' })).toBe(false)
+    })
+
+    it('returns false when password is empty', () => {
+      expect(isLoginPayload({ userName: 'user@test.com', password: '' })).toBe(false)
+    })
+  })
+
+  describe('wrong types', () => {
+    it('returns false when userName is not a string', () => {
+      expect(isLoginPayload({ userName: 123, password: 'secret' })).toBe(false)
+    })
+
+    it('returns false when password is not a string', () => {
+      expect(isLoginPayload({ userName: 'user', password: 123 })).toBe(false)
+    })
+
+    it('returns false when userName is null', () => {
+      expect(isLoginPayload({ userName: null, password: 'secret' })).toBe(false)
+    })
+
+    it('returns false when password is undefined', () => {
+      expect(isLoginPayload({ userName: 'user', password: undefined })).toBe(false)
+    })
+  })
+})

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -3,9 +3,17 @@ import { Button, Form, Input, Paper } from '@furystack/shades-common-components'
 import { navigateToRoute } from '../navigate-to-route.js'
 import { SessionService } from '../services/session.js'
 
-type LoginPayload = {
+export type LoginPayload = {
   userName: string
   password: string
+}
+
+export const isLoginPayload = (data: unknown): data is LoginPayload => {
+  if (typeof data !== 'object' || data === null) return false
+  const d = data as Record<string, unknown>
+  return (
+    typeof d.userName === 'string' && d.userName.length > 0 && typeof d.password === 'string' && d.password.length > 0
+  )
 }
 
 export const Login = Shade({
@@ -30,9 +38,7 @@ export const Login = Shade({
     return (
       <Paper elevation={3} style={{ flexGrow: '1' }}>
         <Form<LoginPayload>
-          validate={(plainData): plainData is LoginPayload => {
-            return !!(plainData as LoginPayload)?.userName?.length && !!(plainData as LoginPayload)?.password?.length
-          }}
+          validate={isLoginPayload}
           className="login-form"
           onSubmit={({ userName, password }) => void sessionService.login(userName, password)}
         >

--- a/frontend/src/pages/register.spec.ts
+++ b/frontend/src/pages/register.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { isRegisterPayload } from './register.js'
+
+describe('isRegisterPayload', () => {
+  describe('valid data', () => {
+    it('returns true for valid payload', () => {
+      expect(isRegisterPayload({ userName: 'user', password: 'pass', confirmPassword: 'pass' })).toBe(true)
+    })
+
+    it('returns true for payload with extra fields', () => {
+      expect(
+        isRegisterPayload({
+          userName: 'user',
+          password: 'pass',
+          confirmPassword: 'pass',
+          extra: 'field',
+        }),
+      ).toBe(true)
+    })
+  })
+
+  describe('primitives and nullish', () => {
+    it('returns false for null', () => {
+      expect(isRegisterPayload(null)).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+      expect(isRegisterPayload(undefined)).toBe(false)
+    })
+
+    it('returns false for string', () => {
+      expect(isRegisterPayload('hello')).toBe(false)
+    })
+
+    it('returns false for number', () => {
+      expect(isRegisterPayload(42)).toBe(false)
+    })
+  })
+
+  describe('missing fields', () => {
+    it('returns false when userName is missing', () => {
+      expect(isRegisterPayload({ password: 'pass', confirmPassword: 'pass' })).toBe(false)
+    })
+
+    it('returns false when password is missing', () => {
+      expect(isRegisterPayload({ userName: 'user', confirmPassword: 'pass' })).toBe(false)
+    })
+
+    it('returns false when confirmPassword is missing', () => {
+      expect(isRegisterPayload({ userName: 'user', password: 'pass' })).toBe(false)
+    })
+
+    it('returns false when all fields are missing', () => {
+      expect(isRegisterPayload({})).toBe(false)
+    })
+  })
+
+  describe('empty string fields', () => {
+    it('returns false when userName is empty', () => {
+      expect(isRegisterPayload({ userName: '', password: 'pass', confirmPassword: 'pass' })).toBe(false)
+    })
+
+    it('returns false when password is empty', () => {
+      expect(isRegisterPayload({ userName: 'user', password: '', confirmPassword: 'pass' })).toBe(false)
+    })
+
+    it('returns false when confirmPassword is empty', () => {
+      expect(isRegisterPayload({ userName: 'user', password: 'pass', confirmPassword: '' })).toBe(false)
+    })
+  })
+
+  describe('wrong types', () => {
+    it('returns false when userName is not a string', () => {
+      expect(isRegisterPayload({ userName: 123, password: 'pass', confirmPassword: 'pass' })).toBe(false)
+    })
+
+    it('returns false when password is not a string', () => {
+      expect(isRegisterPayload({ userName: 'user', password: 123, confirmPassword: 'pass' })).toBe(false)
+    })
+
+    it('returns false when confirmPassword is not a string', () => {
+      expect(isRegisterPayload({ userName: 'user', password: 'pass', confirmPassword: 123 })).toBe(false)
+    })
+  })
+
+  describe('password mismatch', () => {
+    it('returns false when password and confirmPassword do not match', () => {
+      expect(isRegisterPayload({ userName: 'user', password: 'pass1', confirmPassword: 'pass2' })).toBe(false)
+    })
+  })
+})

--- a/frontend/src/pages/register.tsx
+++ b/frontend/src/pages/register.tsx
@@ -47,11 +47,7 @@ export const Register = Shade({
         <Form<RegisterPayload>
           validate={isRegisterPayload}
           className="register-form"
-          onSubmit={({ userName, password, confirmPassword }) => {
-            if (password !== confirmPassword) {
-              sessionService.loginError.setValue('Passwords do not match')
-              return
-            }
+          onSubmit={({ userName, password }) => {
             void sessionService.register(userName, password)
           }}
         >

--- a/frontend/src/pages/register.tsx
+++ b/frontend/src/pages/register.tsx
@@ -3,10 +3,24 @@ import { Button, Form, Input, Paper } from '@furystack/shades-common-components'
 import { navigateToRoute } from '../navigate-to-route.js'
 import { SessionService } from '../services/session.js'
 
-type RegisterPayload = {
+export type RegisterPayload = {
   userName: string
   password: string
   confirmPassword: string
+}
+
+export const isRegisterPayload = (data: unknown): data is RegisterPayload => {
+  if (typeof data !== 'object' || data === null) return false
+  const d = data as Record<string, unknown>
+  return (
+    typeof d.userName === 'string' &&
+    d.userName.length > 0 &&
+    typeof d.password === 'string' &&
+    d.password.length > 0 &&
+    typeof d.confirmPassword === 'string' &&
+    d.confirmPassword.length > 0 &&
+    d.password === d.confirmPassword
+  )
 }
 
 export const Register = Shade({
@@ -31,15 +45,7 @@ export const Register = Shade({
     return (
       <Paper elevation={3} style={{ flexGrow: '1' }}>
         <Form<RegisterPayload>
-          validate={(plainData): plainData is RegisterPayload => {
-            const data = plainData as RegisterPayload
-            return !!(
-              data?.userName?.length &&
-              data?.password?.length &&
-              data?.confirmPassword?.length &&
-              data.password === data.confirmPassword
-            )
-          }}
+          validate={isRegisterPayload}
           className="register-form"
           onSubmit={({ userName, password, confirmPassword }) => {
             if (password !== confirmPassword) {

--- a/frontend/src/pages/user/settings.spec.ts
+++ b/frontend/src/pages/user/settings.spec.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import { isPasswordResetPayload } from './settings.js'
+
+describe('isPasswordResetPayload', () => {
+  describe('valid data', () => {
+    it('returns true for valid payload', () => {
+      expect(
+        isPasswordResetPayload({
+          currentPassword: 'old',
+          newPassword: 'new',
+          confirmPassword: 'confirm',
+        }),
+      ).toBe(true)
+    })
+
+    it('returns true for payload with extra fields', () => {
+      expect(
+        isPasswordResetPayload({
+          currentPassword: 'old',
+          newPassword: 'new',
+          confirmPassword: 'confirm',
+          extra: 'field',
+        }),
+      ).toBe(true)
+    })
+  })
+
+  describe('primitives and nullish', () => {
+    it('returns false for null', () => {
+      expect(isPasswordResetPayload(null)).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+      expect(isPasswordResetPayload(undefined)).toBe(false)
+    })
+
+    it('returns false for string', () => {
+      expect(isPasswordResetPayload('hello')).toBe(false)
+    })
+
+    it('returns false for number', () => {
+      expect(isPasswordResetPayload(42)).toBe(false)
+    })
+  })
+
+  describe('missing fields', () => {
+    it('returns false when currentPassword is missing', () => {
+      expect(isPasswordResetPayload({ newPassword: 'new', confirmPassword: 'confirm' })).toBe(false)
+    })
+
+    it('returns false when newPassword is missing', () => {
+      expect(isPasswordResetPayload({ currentPassword: 'old', confirmPassword: 'confirm' })).toBe(false)
+    })
+
+    it('returns false when confirmPassword is missing', () => {
+      expect(isPasswordResetPayload({ currentPassword: 'old', newPassword: 'new' })).toBe(false)
+    })
+
+    it('returns false when all fields are missing', () => {
+      expect(isPasswordResetPayload({})).toBe(false)
+    })
+  })
+
+  describe('empty string fields', () => {
+    it('returns false when currentPassword is empty', () => {
+      expect(
+        isPasswordResetPayload({
+          currentPassword: '',
+          newPassword: 'new',
+          confirmPassword: 'confirm',
+        }),
+      ).toBe(false)
+    })
+
+    it('returns false when newPassword is empty', () => {
+      expect(
+        isPasswordResetPayload({
+          currentPassword: 'old',
+          newPassword: '',
+          confirmPassword: 'confirm',
+        }),
+      ).toBe(false)
+    })
+
+    it('returns false when confirmPassword is empty', () => {
+      expect(
+        isPasswordResetPayload({
+          currentPassword: 'old',
+          newPassword: 'new',
+          confirmPassword: '',
+        }),
+      ).toBe(false)
+    })
+  })
+
+  describe('wrong types', () => {
+    it('returns false when currentPassword is not a string', () => {
+      expect(
+        isPasswordResetPayload({
+          currentPassword: 123,
+          newPassword: 'new',
+          confirmPassword: 'confirm',
+        }),
+      ).toBe(false)
+    })
+
+    it('returns false when newPassword is not a string', () => {
+      expect(
+        isPasswordResetPayload({
+          currentPassword: 'old',
+          newPassword: 123,
+          confirmPassword: 'confirm',
+        }),
+      ).toBe(false)
+    })
+
+    it('returns false when confirmPassword is not a string', () => {
+      expect(
+        isPasswordResetPayload({
+          currentPassword: 'old',
+          newPassword: 'new',
+          confirmPassword: 123,
+        }),
+      ).toBe(false)
+    })
+  })
+})

--- a/frontend/src/pages/user/settings.spec.ts
+++ b/frontend/src/pages/user/settings.spec.ts
@@ -7,8 +7,8 @@ describe('isPasswordResetPayload', () => {
       expect(
         isPasswordResetPayload({
           currentPassword: 'old',
-          newPassword: 'new',
-          confirmPassword: 'confirm',
+          newPassword: 'newPass',
+          confirmPassword: 'newPass',
         }),
       ).toBe(true)
     })
@@ -17,8 +17,8 @@ describe('isPasswordResetPayload', () => {
       expect(
         isPasswordResetPayload({
           currentPassword: 'old',
-          newPassword: 'new',
-          confirmPassword: 'confirm',
+          newPassword: 'newPass',
+          confirmPassword: 'newPass',
           extra: 'field',
         }),
       ).toBe(true)
@@ -88,6 +88,18 @@ describe('isPasswordResetPayload', () => {
           currentPassword: 'old',
           newPassword: 'new',
           confirmPassword: '',
+        }),
+      ).toBe(false)
+    })
+  })
+
+  describe('password mismatch', () => {
+    it('returns false when newPassword and confirmPassword do not match', () => {
+      expect(
+        isPasswordResetPayload({
+          currentPassword: 'old',
+          newPassword: 'new',
+          confirmPassword: 'different',
         }),
       ).toBe(false)
     })

--- a/frontend/src/pages/user/settings.tsx
+++ b/frontend/src/pages/user/settings.tsx
@@ -3,10 +3,23 @@ import { Button, Form, Input, NotyService, Paper } from '@furystack/shades-commo
 import { ObservableValue } from '@furystack/utils'
 import { SessionService } from '../../services/session.js'
 
-type PasswordResetPayload = {
+export type PasswordResetPayload = {
   currentPassword: string
   newPassword: string
   confirmPassword: string
+}
+
+export const isPasswordResetPayload = (data: unknown): data is PasswordResetPayload => {
+  if (typeof data !== 'object' || data === null) return false
+  const d = data as Record<string, unknown>
+  return (
+    typeof d.currentPassword === 'string' &&
+    d.currentPassword.length > 0 &&
+    typeof d.newPassword === 'string' &&
+    d.newPassword.length > 0 &&
+    typeof d.confirmPassword === 'string' &&
+    d.confirmPassword.length > 0
+  )
 }
 
 const SecuritySection = Shade({
@@ -73,13 +86,7 @@ const SecuritySection = Shade({
           <h4>Change Password</h4>
 
           <Form<PasswordResetPayload>
-            validate={(data): data is PasswordResetPayload => {
-              return !!(
-                (data as PasswordResetPayload)?.currentPassword?.length &&
-                (data as PasswordResetPayload)?.newPassword?.length &&
-                (data as PasswordResetPayload)?.confirmPassword?.length
-              )
-            }}
+            validate={isPasswordResetPayload}
             onSubmit={(data) => {
               void handlePasswordReset(data)
             }}

--- a/frontend/src/pages/user/settings.tsx
+++ b/frontend/src/pages/user/settings.tsx
@@ -18,7 +18,8 @@ export const isPasswordResetPayload = (data: unknown): data is PasswordResetPayl
     typeof d.newPassword === 'string' &&
     d.newPassword.length > 0 &&
     typeof d.confirmPassword === 'string' &&
-    d.confirmPassword.length > 0
+    d.confirmPassword.length > 0 &&
+    d.newPassword === d.confirmPassword
   )
 }
 
@@ -51,11 +52,6 @@ const SecuritySection = Shade({
     const error = useDisposable('error', () => new ObservableValue<string>(''))
 
     const handlePasswordReset = async (data: PasswordResetPayload) => {
-      if (data.newPassword !== data.confirmPassword) {
-        error.setValue('New passwords do not match')
-        return
-      }
-
       isLoading.setValue(true)
       error.setValue('')
 


### PR DESCRIPTION
## ♻️ Summary

Extracts inline form validation callbacks from 15+ frontend components into standalone, exported type guard functions with explicit payload types. Replaces `Record<string, unknown>` casts and manual `FormData` extraction with strongly-typed `onSubmit` callbacks provided by the `Form` component. Refactors `WizardStep` to delegate to `Form` internally.

## 🧪 Tests

Added unit tests for all extracted type guards covering field presence, type checking, empty values, and domain-specific constraints (password matching, URL validation, numeric ranges).
